### PR TITLE
Fix script error on some custom regex.

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,9 @@ Parser.prototype._transform = function(file, encoding, done) {
     var functionRegex = new RegExp( this.regex || pattern, 'g' );
 
     while (( matches = functionRegex.exec( fileContent ) )) {
-        keys.push( matches[1] || matches[2] );
+        if (typeof matches[1] != 'undefined' || typeof matches[2] != 'undefined') {
+            keys.push( matches[1] || matches[2] );
+        }
     }
 
 


### PR DESCRIPTION
I'm not sure if this should be merge, this a bug I have but I'm not sure is this come from me (some error in my Regex) or if this a "normal" behaviour. 

In some case, my custom regex used to extract the translation have some strange behaviour: 

``` javascript
i18next({
    locales: ['en', 'fr'],
    parser: 'this\\.env_\\.filter\\("trans", "(.*)"\\)|,',
    output: '../build/statics/translations/'
});
```

The result is on lines https://github.com/karellm/i18next-parser/blob/282e69c566154bc251b1e3cc3515b1096cd97a94/index.js#L102-L104  the variable `matches` are fill with an array but with an undefined entry 1:

``` javascript
console.log(typeof matches[1] == 'undefined') // true
```

So this patch have to aim to prevent this case.
