### PR TITLE
Add prefix, suffix, change extension and can disable _old file

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ gulp.task('i18next', function() {
 - **keySeparator**: Key separator used in your translation keys. Defaults to `.`
 - **locales**: An array of the locales in your applications. Defaults to `['en','fr']`
 - **parser**: A custom regex for the parser to use.
+- **writeOld**: Save the \_old files. Default to `true`
+- **prefix**: Add a custom prefix in front of the file name.
+- **suffix**: Add a custom suffix at the end of the file name.
+- **extension**: Edit the extension of the files. Defaults to `.json`
 
+You can inject the locale tag in either the prefix, suffix or extension using the `$LOCALE` variable.
 
 ### Note on paths (why your translations are not saved)
 
@@ -275,3 +280,19 @@ The regex used by default is:
 `i18next /path/to/file/or/dir --fileFilter '*.hbs,*.js' --directoryFilter '!.git'`
 
 In recursive mode, it will parse `*.hbs` and `*.js` files and skip `.git` folder. This options is passed to readdirp. To learn more, read [their documentation](https://github.com/thlorenz/readdirp#filters).
+
+
+
+**Work with Meteor TAP-i18N (gulp)**
+
+`.pipe(i18next({
+    output: "i18n",
+    locales: ['en', 'de', 'fr', 'es'],
+    functions: ['_'],
+    namespace: 'client',
+    suffix: '.$LOCALE',
+    extension: ".i18n.json",
+    writeOld: false
+}))`
+
+This will output your files in the format `$LOCALE/client.$LOCALE.i18n.json` in a `i18n/` directory.

--- a/index.js
+++ b/index.js
@@ -188,8 +188,19 @@ Parser.prototype._flush = function(done) {
         for (var namespace in translationsHash) {
 
             // get previous version of the files
-            var namespacePath    = path.resolve( localeBase, this.prefix + namespace + this.suffix + this.extension );
-            var namespaceOldPath = path.resolve( localeBase, this.prefix + namespace + this.suffix + '_old' + this.extension );
+            var prefix = self.prefix;
+            var suffix = self.suffix;
+            var extension = self.extension;
+
+            if ( prefix.split('$LOCALE').length > 1 )
+                prefix = prefix.replace('$LOCALE', locale);
+            if ( suffix.split('$LOCALE').length > 1 )
+                suffix = suffix.replace('$LOCALE', locale);
+            if ( extension.split('$LOCALE').length > 1 )
+                extension = extension.replace('$LOCALE', locale);
+
+            var namespacePath    = path.resolve( localeBase, prefix + namespace + suffix + extension );
+            var namespaceOldPath = path.resolve( localeBase, prefix + namespace + suffix + '_old' + extension );
 
             if ( fs.existsSync( namespacePath ) ) {
                 try {

--- a/index.js
+++ b/index.js
@@ -29,9 +29,10 @@ function Parser(options, transformConfig) {
     this.namespaceSeparator = options.namespaceSeparator || ':';
     this.keySeparator 	    = options.keySeparator || '.';
     this.translations       = [];
+    this.extension         = options.extension || '.json';
     this.suffix             = options.suffix || '';
     this.prefix             = options.prefix || '';
-    this.writeOld           = options.writeOld || true;
+    this.writeOld           = options.writeOld !== false;
 
     ['functions', 'locales'].forEach(function( attr ) {
         if ( (typeof self[ attr ] !== 'object') || ! self[ attr ].length ) {
@@ -187,8 +188,8 @@ Parser.prototype._flush = function(done) {
         for (var namespace in translationsHash) {
 
             // get previous version of the files
-            var namespacePath    = path.resolve( localeBase, this.prefix + namespace + this.suffix + '.json' );
-            var namespaceOldPath = path.resolve( localeBase, this.prefix + namespace + this.suffix + '_old.json' );
+            var namespacePath    = path.resolve( localeBase, this.prefix + namespace + this.suffix + this.extension );
+            var namespaceOldPath = path.resolve( localeBase, this.prefix + namespace + this.suffix + '_old' + this.extension );
 
             if ( fs.existsSync( namespacePath ) ) {
                 try {
@@ -238,7 +239,7 @@ Parser.prototype._flush = function(done) {
             this.emit( 'writing', namespacePath );
             self.push( mergedTranslationsFile );
 
-            if ( !this.writeOld) {
+            if ( self.writeOld) {
                 mergedOldTranslationsFile = new File({
                     path: namespaceOldPath,
                     base: base,

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function Parser(options, transformConfig) {
     this.namespaceSeparator = options.namespaceSeparator || ':';
     this.keySeparator 	    = options.keySeparator || '.';
     this.translations       = [];
-    this.extension         = options.extension || '.json';
+    this.extension          = options.extension || '.json';
     this.suffix             = options.suffix || '';
     this.prefix             = options.prefix || '';
     this.writeOld           = options.writeOld !== false;
@@ -188,19 +188,18 @@ Parser.prototype._flush = function(done) {
         for (var namespace in translationsHash) {
 
             // get previous version of the files
-            var prefix = self.prefix;
-            var suffix = self.suffix;
-            var extension = self.extension;
+            var prefix = self.prefix.replace( '$LOCALE', locale );
+            var suffix = self.suffix.replace( '$LOCALE', locale );
+            var extension = self.extension.replace( '$LOCALE', locale );
 
-            if ( prefix.split('$LOCALE').length > 1 )
-                prefix = prefix.replace('$LOCALE', locale);
-            if ( suffix.split('$LOCALE').length > 1 )
-                suffix = suffix.replace('$LOCALE', locale);
-            if ( extension.split('$LOCALE').length > 1 )
-                extension = extension.replace('$LOCALE', locale);
-
-            var namespacePath    = path.resolve( localeBase, prefix + namespace + suffix + extension );
-            var namespaceOldPath = path.resolve( localeBase, prefix + namespace + suffix + '_old' + extension );
+            var namespacePath = path.resolve(
+                localeBase,
+                prefix + namespace + suffix + extension
+            );
+            var namespaceOldPath = path.resolve(
+                localeBase,
+                prefix + namespace + suffix + '_old' + extension
+            );
 
             if ( fs.existsSync( namespacePath ) ) {
                 try {
@@ -250,7 +249,7 @@ Parser.prototype._flush = function(done) {
             this.emit( 'writing', namespacePath );
             self.push( mergedTranslationsFile );
 
-            if ( self.writeOld) {
+            if ( self.writeOld ) {
                 mergedOldTranslationsFile = new File({
                     path: namespaceOldPath,
                     base: base,

--- a/test/parser.js
+++ b/test/parser.js
@@ -183,7 +183,6 @@ describe('parser', function () {
             results.push(file.relative);
         });
         i18nextParser.on('end', function (file) {
-
             var expectedFiles = [
                 'en/p-en-default-s-en.en.i18n', 'en/p-en-default-s-en_old.en.i18n'
             ];


### PR DESCRIPTION
Enable to add a prefix, a suffix and change the extension. You can also deactivate _old files generations using `writeOld = false;`. You can also use the $LOCALE variable in the prefix/suffix/extension: it will be replaced with the locale tag for each file.
(I'm using TAP-i18n with Meteor and file's name should end with LOCALE_TAG.i18n.json and I can't have the _old files)