### PR TITLE
Support es6 template strings (`` delimeters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ The idea is to parse code files to retrieve the translation keys and create a ca
 - Parses a single file or a directory (recursively or not)
 - Parses template files (support for jade, handlebars and data-i18n attribute in html)
 - Creates one json file per locale and per namespace.
-- Remove old keys your code doesn't use anymore and place them in a `namespace_old.json` file. It is usefull to avoid losing translations you may want to reuse.
+- Remove old keys your code doesn't use anymore and place them in a `namespace_old.json` file. It is useful to avoid losing translations you may want to reuse.
 - Restore keys from the `_old` file if the one in the translation file is empty.
 - Support most i18next features:
     - Handles context keys of the form `key_context`
     - Handles plural keys of the form `key_plural` and `key_plural_0`
     - Handles multiline array in catalog
 - Is a stream transform (so it works with gulp)
+- Supports es6 template strings (in addition to single/double quoted strings) with ${expression} placeholders
 
 
 ---

--- a/index.js
+++ b/index.js
@@ -173,13 +173,8 @@ Parser.prototype._flush = function(done) {
     // into an associative object
     // ==========================
     for (var index in self.translations) {
-        var key = self.translations[index];
-
         // simplify ${dot.separated.variables} into just their tails (${variables})
-        key = key.replace(/\$\{([^}]+)\}/g, function(m, expr) {
-          return '${' + expr.replace(/^([^.]+\.)*/g, '') + '}';
-        })
-
+        var key = self.translations[index].replace( /\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}' );
         translationsHash = helpers.hashFromString( key, self.keySeparator, translationsHash );
     }
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -244,6 +244,33 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('handles es6 template strings with expressions', function (done) {
+        var result;
+        var i18nextParser = Parser();
+        var fakeFile = new File({
+            base: __dirname,
+            contents: new Buffer("asd t(`root.plain`) t(`root.${expr}`) t(`root.${dotted.path}`)")
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.once('end', function (file) {
+            var keys = Object.keys(result);
+            assert.deepEqual(Object.keys(result), ['root']);
+            assert.deepEqual(Object.keys(result.root), [
+              '${path}',
+              '${expr}',
+              'plain'
+            ]);
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
     it('returns buffers', function (done) {
         var i18nextParser = Parser();
         var fakeFile = new File({


### PR DESCRIPTION
This PR adds [es6 template string](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/template_strings) support to the parser.

I also added some code that removes dot-separators from expressions to prevent them from nesting.