### PR TITLE
Add keepRemoved option (cli and gulp) + expose writeOld option to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Thanks a lot to all the previous [contributors](https://github.com/i18next/i18ne
 - **-l, --locales <list>**: The locales in your applications. Defaults to `en,fr`
 - **--directoryFilter**: Globs of folders to filter
 - **--fileFilter**: Globs of files to filter
+- **--keep-removed**: Prevent keys no longer found from being removed
+- **--write-old false**: Avoid saving the \_old files
 
 ---
 
@@ -96,6 +98,7 @@ gulp.task('i18next', function() {
 - **prefix**: Add a custom prefix in front of the file name.
 - **suffix**: Add a custom suffix at the end of the file name.
 - **extension**: Edit the extension of the files. Defaults to `.json`
+- **keepRemoved**: Prevent keys no longer found from being removed
 
 You can inject the locale tag in either the prefix, suffix or extension using the `$LOCALE` variable.
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,6 +26,8 @@ program
   .option( '-l, --locales <list>'                , 'The locales in your application' )
   .option( '--directoryFilter <list>'            , 'Filter directories' )
   .option( '--fileFilter <list>'                 , 'Filter files' )
+  .option( '--keep-removed'                      , 'Prevent keys no longer found from being removed' )
+  .option( '--write-old <string>'                , 'Save (or don\'t if false) _old files' )
   .parse( process.argv );
 
 
@@ -64,6 +66,7 @@ if ( ! fs.existsSync(input) ) {
 // ===================
 program.locales = program.locales && program.locales.split(',');
 program.functions = program.functions && program.functions.split(',');
+program.writeOld = program.writeOld !== 'false';
 program.directoryFilter = program.directoryFilter && program.directoryFilter.split(',');
 program.fileFilter = program.fileFilter && program.fileFilter.split(',');
 program.output = path.resolve(process.cwd(), output);

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function Parser(options, transformConfig) {
     this.suffix             = options.suffix || '';
     this.prefix             = options.prefix || '';
     this.writeOld           = options.writeOld !== false;
+    this.keepRemoved        = options.keepRemoved;
 
     ['functions', 'locales'].forEach(function( attr ) {
         if ( (typeof self[ attr ] !== 'object') || ! self[ attr ].length ) {
@@ -231,7 +232,7 @@ Parser.prototype._flush = function(done) {
 
 
             // merges existing translations with the new ones
-            mergedTranslations = helpers.mergeHash( currentTranslations, translationsHash[namespace] );
+            mergedTranslations = helpers.mergeHash( currentTranslations, translationsHash[namespace], null, this.keepRemoved );
 
             // restore old translations if the key is empty
             mergedTranslations.new = helpers.replaceEmpty( oldTranslations, mergedTranslations.new );

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -28,16 +28,16 @@ function hashFromString(path, separator, hash) {
 
 // Takes a `source` hash and make sure its value
 // are pasted in the `target` hash, if the target
-// hash has the corresponding key. If not, the
-// value is added to an `old` hash.
-function mergeHash(source, target, old) {
+// hash has the corresponding key (or if keepRemoved is true).
+// If not, the value is added to an `old` hash.
+function mergeHash(source, target, old, keepRemoved) {
     target = target || {};
     old    = old || {};
 
     Object.keys(source).forEach(function (key) {
         if ( target[key] !== undefined ) {
             if (typeof source[key] === 'object' && source[key].constructor !== Array) {
-                var nested = mergeHash( source[key], target[key], old[key] );
+                var nested = mergeHash( source[key], target[key], old[key], keepRemoved );
                 target[key] = nested.new;
                 old[key] = nested.old;
             }
@@ -61,6 +61,9 @@ function mergeHash(source, target, old) {
                 target[key] = source[key];
             }
             else {
+                if (keepRemoved) {
+                  target[key] = source[key];
+                }
                 old[key] = source[key];
             }
         }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -29,6 +29,16 @@ describe('mergeHash helper function', function () {
         done();
     });
 
+    it('copies `source` keys to `target` regardless of presence when keepRemoved is enabled', function (done) {
+        var source = { key1: 'value1', key2: 'value2' };
+        var target = { key1: '', key3: '' };
+        var res    = mergeHash(source, target, null, true);
+
+        assert.deepEqual(res.new, { key1: 'value1', key2: 'value2', key3: '' });
+        assert.deepEqual(res.old, { key2: 'value2' });
+        done();
+    });
+
     it('restores plural keys when the singular one exists', function (done) {
         var source = { key1: '', key1_plural: 'value1' };
         var target = { key1: '' };


### PR DESCRIPTION
* Add `keepRemoved` (`--keep-removed`) option which, when enabled, prevents the parser from removing translation keys present in the existing json files when not found in the source code.
* Expose `writeOld` option to cli as `--no-old` (since default is to write them).
* Add `keepRemoved` option test (part of `mergeHash`)