### PR TITLE
Display an error when the matches function's first arg is not a string literal

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -123,6 +123,10 @@ else {
 // Parse the stream
 // ================
 var parser = Parser(program);
+parser.on('error', function(message, region) {
+  console.log("[error] ".red + message + ": " + region.trim());
+  process.exit(1)
+});
 
 stream
   .pipe(through( { objectMode: true }, function (data, encoding, done) {

--- a/index.js
+++ b/index.js
@@ -117,6 +117,14 @@ Parser.prototype._transform = function(file, encoding, done) {
     }
 
 
+    // and we parse for functions with variables instead of string literals
+    // ====================================
+    noStringLiteralPattern = '.*[^a-zA-Z0-9_](?:'+fnPattern+')(?:\\(|\\s)\\s*(?:[^\'"`\)]+\\)).*'
+    if ( matches = new RegExp( noStringLiteralPattern, 'g' ).exec( fileContent )) {
+        this.emit( 'error', 'first argument to function needs to be a string literal', matches[0] )
+    }
+
+
     // and we parse for attributes in html
     // =============================================
     const attributes = '(?:' + this.attributes.join('|') + ')';

--- a/test/parser.js
+++ b/test/parser.js
@@ -408,4 +408,20 @@ describe('parser', function () {
 
         i18nextParser.end(fakeFile);
     });
+
+
+    it('fails to parse first parameter not string literal', function (done) {
+        var i18nextParser = Parser();
+        var fakeFile = new File({
+            contents: new Buffer("asd t(firstVar)\n")
+        });
+
+        i18nextParser.on('error', function (message, region) {
+            assert.equal( message, "first argument to function needs to be a string literal" );
+            assert.equal( region, "asd t(firstVar)" )
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
 });


### PR DESCRIPTION
If someone tried to call the translation function with a variable, currently the parser will fail silently. This makes it an error to call the translation function on a string which cannot be extracted (and thus will never be translated).