### PR TITLE
Handle strings with newlines, tabs and backslashes in them.

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,8 +153,13 @@ Parser.prototype._transform = function(file, encoding, done) {
     // finally we add the parsed keys to the catalog
     // =============================================
     for (var j in keys) {
+        var key = keys[j];
         // remove the backslash from escaped quotes
-        var key = keys[j].replace(/\\('|"|`)/g, '$1');
+        key = key.replace(/\\('|"|`)/g, '$1')
+        key = key.replace(/\\n/g, '\n');
+        key = key.replace(/\\r/g, '\r');
+        key = key.replace(/\\t/g, '\t');
+        key = key.replace(/\\\\/g, '\\');
 
         if ( key.indexOf( self.namespaceSeparator ) == -1 ) {
             key = self.defaultNamespace + self.keySeparator + key;

--- a/test/parser.js
+++ b/test/parser.js
@@ -244,6 +244,28 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('handles escaped characters', function (done) {
+        var result;
+        var i18nextParser = Parser();
+        var fakeFile = new File({
+            base: __dirname,
+            contents: new Buffer("asd t('escaped backslash\\\\ newline\\n\\r tab\\t')")
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.once('end', function (file) {
+            var keys = Object.keys(result);
+            assert.equal( keys[0], 'escaped backslash\\ newline\n\r tab\t' );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
     it('handles es6 template strings with expressions', function (done) {
         var result;
         var i18nextParser = Parser();


### PR DESCRIPTION
Previously we sending translators `"Strings with:\\ndouble-escaped newlines"`. This fixes the issue.