### PR TITLE
Add parsing of context in option of translation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Thanks a lot to all the previous [contributors](https://github.com/i18next/i18ne
 - **-n, --namespace <string>**: Default namespace used in your i18next config. Defaults to `translation`
 - **-s, --namespace-separator <string>**: Namespace separator used in your translation keys. Defaults to `:`
 - **-k, --key-separator <string>**: Key separator used in your translation keys. Defaults to `.`
+- **-k, --context-separator <string>**: Context separator used in your translation keys. Defaults to `_`
 - **-l, --locales <list>**: The locales in your applications. Defaults to `en,fr`
 - **--directoryFilter**: Globs of folders to filter
 - **--fileFilter**: Globs of files to filter

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Thanks a lot to all the previous [contributors](https://github.com/i18next/i18ne
 - **-n, --namespace <string>**: Default namespace used in your i18next config. Defaults to `translation`
 - **-s, --namespace-separator <string>**: Namespace separator used in your translation keys. Defaults to `:`
 - **-k, --key-separator <string>**: Key separator used in your translation keys. Defaults to `.`
-- **-k, --context-separator <string>**: Context separator used in your translation keys. Defaults to `_`
+- **-c, --context-separator <string>**: Context separator used in your translation keys. Defaults to `_`
 - **-l, --locales <list>**: The locales in your applications. Defaults to `en,fr`
 - **--directoryFilter**: Globs of folders to filter
 - **--fileFilter**: Globs of files to filter

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,6 +24,7 @@ program
   .option( '-n, --namespace <string>'            , 'The default namespace (translation by default)' )
   .option( '-s, --namespace-separator <string>'  , 'The default namespace separator(: by default)' )
   .option( '-k, --key-separator <string>'        , 'The default key separator(. by default)' )
+  .option( '-c, --context-separator <string>'    , 'The default context separator(_ by default)' )
   .option( '-l, --locales <list>'                , 'The locales in your application' )
   .option( '--directoryFilter <list>'            , 'Filter directories' )
   .option( '--fileFilter <list>'                 , 'Filter files' )

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ Parser.prototype._transform = function(file, encoding, done) {
             if (context) {
                 key += this.contextSeparator + context;
             }
-            keys.push(key);
+            keys.push( key );
         }
     }
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -462,9 +462,7 @@ describe('parser', function () {
 
     it('parses context passed as object', function (done) {
         var result;
-        var i18nextParser = Parser({
-          attributes: ['data-i18n', 'translate', 't']
-        });
+        var i18nextParser = Parser();
         var fakeFile = new File({
             contents: new Buffer('t("first", {context: \'date\'}) t("second", { "context": \'form2\'}) t(`third`, { \'context\' : `context` }) t("fourth", { "context" : "pipo"})')
         });

--- a/test/parser.js
+++ b/test/parser.js
@@ -459,4 +459,25 @@ describe('parser', function () {
         });
         i18nextParser.end(fakeFile);
     });
+
+    it('parses context passed as object', function (done) {
+        var result;
+        var i18nextParser = Parser({
+          attributes: ['data-i18n', 'translate', 't']
+        });
+        var fakeFile = new File({
+            contents: new Buffer('t("first", {context: \'date\'}) t("second", { "context": \'form2\'}) t(`third`, { \'context\' : `context` }) t("fourth", { "context" : "pipo"})')
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            assert.deepEqual( result, { first_date: '', second_form2: '', third_context: '', fourth_pipo: '' } );
+            done();
+        });
+        i18nextParser.end(fakeFile);
+    });
 });


### PR DESCRIPTION
- Regex has been updated to match options
- If a `context` is found, it will define key as `key_context`
- add param to change context separator (`_` by default)

Solves https://github.com/i18next/i18next-parser/issues/46