### PR TITLE
Hotfix/issue50

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,18 +18,12 @@ function Parser(options, transformConfig) {
 
     var self = this;
 
-    options = options || {};
+    options         = options || {};
     transformConfig = transformConfig || {};
 
     this.defaultNamespace       = options.namespace || 'translation';
     this.functions              = options.functions || ['t'];
     this.locales                = options.locales || ['en','fr'];
-    this.output                 = options.output || 'locales';
-    this.regex                  = options.parser;
-    this.attributes             = options.attributes || ['data-i18n'];
-    this.defaultNamespace       = options.namespace || 'translation';
-    this.functions              = options.functions || ['t'];
-    this.locales                = options.locales || ['en', 'fr'];
     this.output                 = options.output || 'locales';
     this.regex                  = options.parser;
     this.attributes             = options.attributes || ['data-i18n'];
@@ -45,9 +39,9 @@ function Parser(options, transformConfig) {
     this.ignoreVariables        = options.ignoreVariables || false;
     this.includeSingleQuoted    = options.includeSingleQuoted || false;
 
-    ['functions', 'locales'].forEach(function (attr) {
-        if ((typeof self[attr] !== 'object') || !self[attr].length) {
-            throw new PluginError(PLUGIN_NAME, '`' + attr + '` must be an array');
+    ['functions', 'locales'].forEach(function( attr ) {
+        if ( (typeof self[ attr ] !== 'object') || ! self[ attr ].length ) {
+            throw new PluginError(PLUGIN_NAME, '`'+attr+'` must be an array');
         }
     });
 
@@ -58,17 +52,17 @@ util.inherits(Parser, Transform);
 
 
 
-Parser.prototype._transform = function (file, encoding, done) {
+Parser.prototype._transform = function(file, encoding, done) {
 
-    var self = this;
-    this.base = this.base || file.base;
+    var self        = this;
+    this.base       = this.base || file.base;
 
 
 
     // we do not handle streams
     // ========================
     if (file.isStream()) {
-        this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported'));
+        this.emit( 'error', new PluginError( PLUGIN_NAME, 'Streams not supported' ) );
         return done();
     }
 
@@ -76,15 +70,15 @@ Parser.prototype._transform = function (file, encoding, done) {
 
     // get the file from file path
     // ===========================
-    if (file.isNull()) {
-        if (file.stat.isDirectory()) {
+    if(file.isNull()) {
+        if ( file.stat.isDirectory() ) {
             return done();
         }
-        else if (file.path && fs.existsSync(file.path)) {
-            data = fs.readFileSync(file.path);
+        else if ( file.path && fs.existsSync( file.path ) ) {
+            data = fs.readFileSync( file.path );
         }
         else {
-            this.emit('error', new PluginError(PLUGIN_NAME, 'File has no content and is not readable'));
+            this.emit( 'error', new PluginError( PLUGIN_NAME, 'File has no content and is not readable' ) );
             return done();
         }
     }
@@ -93,7 +87,7 @@ Parser.prototype._transform = function (file, encoding, done) {
 
     // we handle buffers
     // =================
-    if (file.isBuffer()) {
+    if(file.isBuffer()) {
         data = file.contents;
     }
 
@@ -105,34 +99,34 @@ Parser.prototype._transform = function (file, encoding, done) {
     var keys = [];
     var matches;
 
-    this.emit('reading', file.path);
+    this.emit( 'reading', file.path );
 
 
     // and we parse for functions...
     // =============================
-    var fnPattern = this.functions.join('|').replace('.', '\\.');
+    var fnPattern = this.functions.join( '|' ).replace( '.', '\\.' );
     var singleQuotePattern = "'([^\'].*?[^\\\\])?'";
     var doubleQuotePattern = '"([^\"].*?[^\\\\])?"';
-    var backQuotePattern = '`([^\`].*?[^\\\\])?`';
+    var backQuotePattern   = '`([^\`].*?[^\\\\])?`';
     var stringPattern = '(?:' + singleQuotePattern + '|' + doubleQuotePattern + '|' + backQuotePattern + ')';
     var pattern = '.*?(?:' + fnPattern + ')\\s*\\(?\\s*' + stringPattern + '(?:(?:[^).]*?)\\{(?:.*?)(?:(?:context|\'context\'|"context")\\s*:\\s*' + stringPattern + '(?:.*?)\\}))?';
 
-    var functionRegex = new RegExp(this.regex || pattern, 'g');
-    while ((matches = functionRegex.exec(fileContent))) {
+    var functionRegex = new RegExp( this.regex || pattern, 'g' );
+    while (( matches = functionRegex.exec( fileContent ) )) {
         var key = matches[1] || matches[2] || matches[3];
         if (key) {
             var context = matches[4] || matches[5] || matches[6];
             if (context) {
                 key += this.contextSeparator + context;
             }
-            keys.push(key);
+            keys.push( key );
         }
     }
 
     // and we parse for functions with variables instead of string literals
     // ====================================================================
-    var noStringLiteralPattern = '[^a-zA-Z0-9_\'"`]((?:' + fnPattern + ')(?:\\()\\s*(?:[^\'"`\)]+\\)))';
-    var matches = new RegExp(noStringLiteralPattern, 'g').exec(fileContent);
+    var noStringLiteralPattern = '[^a-zA-Z0-9_\'"`]((?:'+fnPattern+')(?:\\()\\s*(?:[^\'"`\)]+\\)))';
+    var matches = new RegExp( noStringLiteralPattern, 'g' ).exec( fileContent );
     if (matches && matches.length) {
         if (!this.ignoreVariables) {
             this.emit(
@@ -148,21 +142,22 @@ Parser.prototype._transform = function (file, encoding, done) {
     // and we parse for attributes in html
     // ===================================
     const attributes = '(?:' + this.attributes.join('|') + ')';
-    var attributeWithValueRegex = new RegExp('(?:\\W+' + attributes + '=")([^"]*)(?:")', 'gi');
+    var attributeWithValueRegex = new RegExp( '(?:\\W+' + attributes + '=")([^"]*)(?:")', 'gi' );
     var attributeWithValueRegexSingleQuotes = new RegExp("(?:\\W+" + attributes + "=')([^']*)(?:')", 'gi');
-    var attributeWithoutValueRegex = new RegExp('<([A-Z][A-Z0-9]*)(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*(?:(?:\\s+' + attributes + '))(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*\\s*(?:>(.*?)<\\/\\1>)', 'gi');
+    var attributeWithoutValueRegex = new RegExp( '<([A-Z][A-Z0-9]*)(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*(?:(?:\\s+' + attributes + '))(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*\\s*(?:>(.*?)<\\/\\1>)', 'gi' );
 
-    while ((matches = attributeWithValueRegex.exec(fileContent))) {
+    while (( matches = attributeWithValueRegex.exec( fileContent ) )) {
         matchKeys = matches[1].split(';');
 
         for (var i in matchKeys) {
             // remove any leading [] in the key
-            keys.push(matchKeys[i].replace(/^\[[a-zA-Z0-9_-]*\]/, ''));
+            keys.push( matchKeys[i].replace( /^\[[a-zA-Z0-9_-]*\]/ , '' ) );
         }
     }
-    //and is specifies in options (includeSingleQuoted) also for single-quoted attributes 
+
+    //and if specified in options (includeSingleQuoted) also for single-quoted attributes 
     if (this.includeSingleQuoted) {
-        while ((matches = attributeWithValueRegexSingleQuotes.exec(fileContent))) {
+        while (( matches = attributeWithValueRegexSingleQuotes.exec( fileContent ) )) {
             matchKeys = matches[1].split(';');
 
             for (var i in matchKeys) {
@@ -172,8 +167,8 @@ Parser.prototype._transform = function (file, encoding, done) {
         }
     }
 
-    while ((matches = attributeWithoutValueRegex.exec(fileContent))) {
-        keys.push(matches[2]);
+    while (( matches = attributeWithoutValueRegex.exec( fileContent ) )) {
+        keys.push( matches[2] );
     }
 
 
@@ -188,14 +183,14 @@ Parser.prototype._transform = function (file, encoding, done) {
         key = key.replace(/\\t/g, '\t');
         key = key.replace(/\\\\/g, '\\');
 
-        if (key.indexOf(self.namespaceSeparator) == -1) {
+        if ( key.indexOf( self.namespaceSeparator ) == -1 ) {
             key = self.defaultNamespace + self.keySeparator + key;
         }
         else {
-            key = key.replace(self.namespaceSeparator, self.keySeparator);
+            key = key.replace( self.namespaceSeparator, self.keySeparator );
         }
 
-        self.translations.push(key);
+        self.translations.push( key );
     }
 
     done();
@@ -203,17 +198,17 @@ Parser.prototype._transform = function (file, encoding, done) {
 
 
 
-Parser.prototype._flush = function (done) {
+Parser.prototype._flush = function(done) {
 
     var self = this;
-    var base = path.resolve(self.base, self.output);
+    var base = path.resolve( self.base, self.output );
     var translationsHash = {};
 
 
 
     // remove duplicate keys
     // =====================
-    self.translations = _.uniq(self.translations).sort();
+    self.translations = _.uniq( self.translations ).sort();
 
 
 
@@ -222,8 +217,8 @@ Parser.prototype._flush = function (done) {
     // ==========================
     for (var index in self.translations) {
         // simplify ${dot.separated.variables} into just their tails (${variables})
-        var key = self.translations[index].replace(/\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}');
-        translationsHash = helpers.hashFromString(key, self.keySeparator, translationsHash);
+        var key = self.translations[index].replace( /\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}' );
+        translationsHash = helpers.hashFromString( key, self.keySeparator, translationsHash );
     }
 
 
@@ -231,15 +226,15 @@ Parser.prototype._flush = function (done) {
     // process each locale and namespace
     // =================================
     for (var i in self.locales) {
-        var locale = self.locales[i];
-        var localeBase = path.resolve(self.base, self.output, locale);
+        var locale     = self.locales[i];
+        var localeBase = path.resolve( self.base, self.output, locale );
 
         for (var namespace in translationsHash) {
 
             // get previous version of the files
-            var prefix = self.prefix.replace('$LOCALE', locale);
-            var suffix = self.suffix.replace('$LOCALE', locale);
-            var extension = self.extension.replace('$LOCALE', locale);
+            var prefix = self.prefix.replace( '$LOCALE', locale );
+            var suffix = self.suffix.replace( '$LOCALE', locale );
+            var extension = self.extension.replace( '$LOCALE', locale );
 
             var namespacePath = path.resolve(
                 localeBase,
@@ -250,12 +245,12 @@ Parser.prototype._flush = function (done) {
                 prefix + namespace + suffix + '_old' + extension
             );
 
-            if (fs.existsSync(namespacePath)) {
+            if ( fs.existsSync( namespacePath ) ) {
                 try {
-                    currentTranslations = JSON.parse(fs.readFileSync(namespacePath));
+                    currentTranslations = JSON.parse( fs.readFileSync( namespacePath ) );
                 }
                 catch (error) {
-                    this.emit('json_error', error.name, error.message);
+                    this.emit( 'json_error', error.name, error.message );
                     currentTranslations = {};
                 }
             }
@@ -263,12 +258,12 @@ Parser.prototype._flush = function (done) {
                 currentTranslations = {};
             }
 
-            if (fs.existsSync(namespaceOldPath)) {
+            if ( fs.existsSync( namespaceOldPath ) ) {
                 try {
-                    oldTranslations = JSON.parse(fs.readFileSync(namespaceOldPath));
+                    oldTranslations = JSON.parse( fs.readFileSync( namespaceOldPath ) );
                 }
                 catch (error) {
-                    this.emit('json_error', error.name, error.message);
+                    this.emit( 'json_error', error.name, error.message );
                     currentTranslations = {};
                 }
             }
@@ -279,33 +274,33 @@ Parser.prototype._flush = function (done) {
 
 
             // merges existing translations with the new ones
-            mergedTranslations = helpers.mergeHash(currentTranslations, translationsHash[namespace], null, this.keepRemoved);
+            mergedTranslations = helpers.mergeHash( currentTranslations, translationsHash[namespace], null, this.keepRemoved );
 
             // restore old translations if the key is empty
-            mergedTranslations.new = helpers.replaceEmpty(oldTranslations, mergedTranslations.new);
+            mergedTranslations.new = helpers.replaceEmpty( oldTranslations, mergedTranslations.new );
 
             // merges former old translations with the new ones
-            mergedTranslations.old = _.extend(oldTranslations, mergedTranslations.old);
+            mergedTranslations.old = _.extend( oldTranslations, mergedTranslations.old );
 
 
 
             // push files back to the stream
             mergedTranslationsFile = new File({
-                path: namespacePath,
-                base: base,
-                contents: new Buffer(JSON.stringify(mergedTranslations.new, null, 2))
+              path: namespacePath,
+              base: base,
+              contents: new Buffer( JSON.stringify( mergedTranslations.new, null, 2 ) )
             });
-            this.emit('writing', namespacePath);
-            self.push(mergedTranslationsFile);
+            this.emit( 'writing', namespacePath );
+            self.push( mergedTranslationsFile );
 
-            if (self.writeOld) {
+            if ( self.writeOld ) {
                 mergedOldTranslationsFile = new File({
                     path: namespaceOldPath,
                     base: base,
                     contents: new Buffer(JSON.stringify(mergedTranslations.old, null, 2))
                 });
-                this.emit('writing', namespaceOldPath);
-                self.push(mergedOldTranslationsFile);
+                this.emit( 'writing', namespaceOldPath );
+                self.push( mergedOldTranslationsFile );
             }
 
 
@@ -317,6 +312,6 @@ Parser.prototype._flush = function (done) {
 
 
 
-module.exports = function (options, transformConfig) {
+module.exports = function(options, transformConfig) {
     return new Parser(options, transformConfig);
 };

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-var gutil       = require('gulp-util');
+var gutil = require('gulp-util');
 var PluginError = gutil.PluginError;
-var Transform   = require('stream').Transform;
-var util        = require('util');
-var helpers     = require('./src/helpers');
-var fs          = require('fs');
-var File        = require('vinyl');
-var path        = require('path');
-var _           = require('lodash');
+var Transform = require('stream').Transform;
+var util = require('util');
+var helpers = require('./src/helpers');
+var fs = require('fs');
+var File = require('vinyl');
+var path = require('path');
+var _ = require('lodash');
 
 
 
@@ -18,29 +18,30 @@ function Parser(options, transformConfig) {
 
     var self = this;
 
-    options         = options || {};
+    options = options || {};
     transformConfig = transformConfig || {};
 
-    this.defaultNamespace   = options.namespace || 'translation';
-    this.functions          = options.functions || ['t'];
-    this.locales            = options.locales || ['en','fr'];
-    this.output             = options.output || 'locales';
-    this.regex              = options.parser;
-    this.attributes         = options.attributes || ['data-i18n'];
+    this.defaultNamespace = options.namespace || 'translation';
+    this.functions = options.functions || ['t'];
+    this.locales = options.locales || ['en', 'fr'];
+    this.output = options.output || 'locales';
+    this.regex = options.parser;
+    this.attributes = options.attributes || ['data-i18n'];
     this.namespaceSeparator = options.namespaceSeparator || ':';
-    this.keySeparator       = options.keySeparator || '.';
-    this.contextSeparator   = options.contextSeparator || '_';
-    this.translations       = [];
-    this.extension          = options.extension || '.json';
-    this.suffix             = options.suffix || '';
-    this.prefix             = options.prefix || '';
-    this.writeOld           = options.writeOld !== false;
-    this.keepRemoved        = options.keepRemoved;
-    this.ignoreVariables    = options.ignoreVariables || false;
+    this.keySeparator = options.keySeparator || '.';
+    this.contextSeparator = options.contextSeparator || '_';
+    this.translations = [];
+    this.extension = options.extension || '.json';
+    this.suffix = options.suffix || '';
+    this.prefix = options.prefix || '';
+    this.writeOld = options.writeOld !== false;
+    this.keepRemoved = options.keepRemoved;
+    this.ignoreVariables = options.ignoreVariables || false;
+    this.includeSingleQuoted = options.includeSingleQuoted || false;
 
-    ['functions', 'locales'].forEach(function( attr ) {
-        if ( (typeof self[ attr ] !== 'object') || ! self[ attr ].length ) {
-            throw new PluginError(PLUGIN_NAME, '`'+attr+'` must be an array');
+    ['functions', 'locales'].forEach(function (attr) {
+        if ((typeof self[attr] !== 'object') || !self[attr].length) {
+            throw new PluginError(PLUGIN_NAME, '`' + attr + '` must be an array');
         }
     });
 
@@ -51,17 +52,17 @@ util.inherits(Parser, Transform);
 
 
 
-Parser.prototype._transform = function(file, encoding, done) {
+Parser.prototype._transform = function (file, encoding, done) {
 
-    var self        = this;
-    this.base       = this.base || file.base;
+    var self = this;
+    this.base = this.base || file.base;
 
 
 
     // we do not handle streams
     // ========================
     if (file.isStream()) {
-        this.emit( 'error', new PluginError( PLUGIN_NAME, 'Streams not supported' ) );
+        this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported'));
         return done();
     }
 
@@ -69,15 +70,15 @@ Parser.prototype._transform = function(file, encoding, done) {
 
     // get the file from file path
     // ===========================
-    if(file.isNull()) {
-        if ( file.stat.isDirectory() ) {
+    if (file.isNull()) {
+        if (file.stat.isDirectory()) {
             return done();
         }
-        else if ( file.path && fs.existsSync( file.path ) ) {
-            data = fs.readFileSync( file.path );
+        else if (file.path && fs.existsSync(file.path)) {
+            data = fs.readFileSync(file.path);
         }
         else {
-            this.emit( 'error', new PluginError( PLUGIN_NAME, 'File has no content and is not readable' ) );
+            this.emit('error', new PluginError(PLUGIN_NAME, 'File has no content and is not readable'));
             return done();
         }
     }
@@ -86,7 +87,7 @@ Parser.prototype._transform = function(file, encoding, done) {
 
     // we handle buffers
     // =================
-    if(file.isBuffer()) {
+    if (file.isBuffer()) {
         data = file.contents;
     }
 
@@ -98,34 +99,34 @@ Parser.prototype._transform = function(file, encoding, done) {
     var keys = [];
     var matches;
 
-    this.emit( 'reading', file.path );
+    this.emit('reading', file.path);
 
 
     // and we parse for functions...
     // =============================
-    var fnPattern = this.functions.join( '|' ).replace( '.', '\\.' );
+    var fnPattern = this.functions.join('|').replace('.', '\\.');
     var singleQuotePattern = "'([^\'].*?[^\\\\])?'";
     var doubleQuotePattern = '"([^\"].*?[^\\\\])?"';
-    var backQuotePattern   = '`([^\`].*?[^\\\\])?`';
+    var backQuotePattern = '`([^\`].*?[^\\\\])?`';
     var stringPattern = '(?:' + singleQuotePattern + '|' + doubleQuotePattern + '|' + backQuotePattern + ')';
     var pattern = '.*?(?:' + fnPattern + ')\\s*\\(?\\s*' + stringPattern + '(?:(?:[^).]*?)\\{(?:.*?)(?:(?:context|\'context\'|"context")\\s*:\\s*' + stringPattern + '(?:.*?)\\}))?';
 
-    var functionRegex = new RegExp( this.regex || pattern, 'g' );
-    while (( matches = functionRegex.exec( fileContent ) )) {
+    var functionRegex = new RegExp(this.regex || pattern, 'g');
+    while ((matches = functionRegex.exec(fileContent))) {
         var key = matches[1] || matches[2] || matches[3];
         if (key) {
             var context = matches[4] || matches[5] || matches[6];
             if (context) {
                 key += this.contextSeparator + context;
             }
-            keys.push( key );
+            keys.push(key);
         }
     }
 
     // and we parse for functions with variables instead of string literals
     // ====================================================================
-    var noStringLiteralPattern = '[^a-zA-Z0-9_\'"`]((?:'+fnPattern+')(?:\\()\\s*(?:[^\'"`\)]+\\)))';
-    var matches = new RegExp( noStringLiteralPattern, 'g' ).exec( fileContent );
+    var noStringLiteralPattern = '[^a-zA-Z0-9_\'"`]((?:' + fnPattern + ')(?:\\()\\s*(?:[^\'"`\)]+\\)))';
+    var matches = new RegExp(noStringLiteralPattern, 'g').exec(fileContent);
     if (matches && matches.length) {
         if (!this.ignoreVariables) {
             this.emit(
@@ -141,20 +142,32 @@ Parser.prototype._transform = function(file, encoding, done) {
     // and we parse for attributes in html
     // ===================================
     const attributes = '(?:' + this.attributes.join('|') + ')';
-    var attributeWithValueRegex = new RegExp( '(?:\\W+' + attributes + '=")([^"]*)(?:")', 'gi' );
-    var attributeWithoutValueRegex = new RegExp( '<([A-Z][A-Z0-9]*)(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*(?:(?:\\s+' + attributes + '))(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*\\s*(?:>(.*?)<\\/\\1>)', 'gi' );
+    var attributeWithValueRegex = new RegExp('(?:\\W+' + attributes + '=")([^"]*)(?:")', 'gi');
+    var attributeWithValueRegexSingleQuotes = new RegExp("(?:\\W+" + attributes + "=')([^']*)(?:')", 'gi');
+    var attributeWithoutValueRegex = new RegExp('<([A-Z][A-Z0-9]*)(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*(?:(?:\\s+' + attributes + '))(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*\\s*(?:>(.*?)<\\/\\1>)', 'gi');
 
-    while (( matches = attributeWithValueRegex.exec( fileContent ) )) {
+    while ((matches = attributeWithValueRegex.exec(fileContent))) {
         matchKeys = matches[1].split(';');
 
         for (var i in matchKeys) {
             // remove any leading [] in the key
-            keys.push( matchKeys[i].replace( /^\[[a-zA-Z0-9_-]*\]/ , '' ) );
+            keys.push(matchKeys[i].replace(/^\[[a-zA-Z0-9_-]*\]/, ''));
+        }
+    }
+    //and is specifies in options (includeSingleQuoted) also for single-quoted attributes 
+    if (this.includeSingleQuoted) {
+        while ((matches = attributeWithValueRegexSingleQuotes.exec(fileContent))) {
+            matchKeys = matches[1].split(';');
+
+            for (var i in matchKeys) {
+                // remove any leading [] in the key
+                keys.push(matchKeys[i].replace(/^\[[a-zA-Z0-9_-]*\]/, ''));
+            }
         }
     }
 
-    while (( matches = attributeWithoutValueRegex.exec( fileContent ) )) {
-        keys.push( matches[2] );
+    while ((matches = attributeWithoutValueRegex.exec(fileContent))) {
+        keys.push(matches[2]);
     }
 
 
@@ -169,14 +182,14 @@ Parser.prototype._transform = function(file, encoding, done) {
         key = key.replace(/\\t/g, '\t');
         key = key.replace(/\\\\/g, '\\');
 
-        if ( key.indexOf( self.namespaceSeparator ) == -1 ) {
+        if (key.indexOf(self.namespaceSeparator) == -1) {
             key = self.defaultNamespace + self.keySeparator + key;
         }
         else {
-            key = key.replace( self.namespaceSeparator, self.keySeparator );
+            key = key.replace(self.namespaceSeparator, self.keySeparator);
         }
 
-        self.translations.push( key );
+        self.translations.push(key);
     }
 
     done();
@@ -184,17 +197,17 @@ Parser.prototype._transform = function(file, encoding, done) {
 
 
 
-Parser.prototype._flush = function(done) {
+Parser.prototype._flush = function (done) {
 
     var self = this;
-    var base = path.resolve( self.base, self.output );
+    var base = path.resolve(self.base, self.output);
     var translationsHash = {};
 
 
 
     // remove duplicate keys
     // =====================
-    self.translations = _.uniq( self.translations ).sort();
+    self.translations = _.uniq(self.translations).sort();
 
 
 
@@ -203,8 +216,8 @@ Parser.prototype._flush = function(done) {
     // ==========================
     for (var index in self.translations) {
         // simplify ${dot.separated.variables} into just their tails (${variables})
-        var key = self.translations[index].replace( /\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}' );
-        translationsHash = helpers.hashFromString( key, self.keySeparator, translationsHash );
+        var key = self.translations[index].replace(/\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}');
+        translationsHash = helpers.hashFromString(key, self.keySeparator, translationsHash);
     }
 
 
@@ -212,15 +225,15 @@ Parser.prototype._flush = function(done) {
     // process each locale and namespace
     // =================================
     for (var i in self.locales) {
-        var locale     = self.locales[i];
-        var localeBase = path.resolve( self.base, self.output, locale );
+        var locale = self.locales[i];
+        var localeBase = path.resolve(self.base, self.output, locale);
 
         for (var namespace in translationsHash) {
 
             // get previous version of the files
-            var prefix = self.prefix.replace( '$LOCALE', locale );
-            var suffix = self.suffix.replace( '$LOCALE', locale );
-            var extension = self.extension.replace( '$LOCALE', locale );
+            var prefix = self.prefix.replace('$LOCALE', locale);
+            var suffix = self.suffix.replace('$LOCALE', locale);
+            var extension = self.extension.replace('$LOCALE', locale);
 
             var namespacePath = path.resolve(
                 localeBase,
@@ -231,12 +244,12 @@ Parser.prototype._flush = function(done) {
                 prefix + namespace + suffix + '_old' + extension
             );
 
-            if ( fs.existsSync( namespacePath ) ) {
+            if (fs.existsSync(namespacePath)) {
                 try {
-                    currentTranslations = JSON.parse( fs.readFileSync( namespacePath ) );
+                    currentTranslations = JSON.parse(fs.readFileSync(namespacePath));
                 }
                 catch (error) {
-                    this.emit( 'json_error', error.name, error.message );
+                    this.emit('json_error', error.name, error.message);
                     currentTranslations = {};
                 }
             }
@@ -244,12 +257,12 @@ Parser.prototype._flush = function(done) {
                 currentTranslations = {};
             }
 
-            if ( fs.existsSync( namespaceOldPath ) ) {
+            if (fs.existsSync(namespaceOldPath)) {
                 try {
-                    oldTranslations = JSON.parse( fs.readFileSync( namespaceOldPath ) );
+                    oldTranslations = JSON.parse(fs.readFileSync(namespaceOldPath));
                 }
                 catch (error) {
-                    this.emit( 'json_error', error.name, error.message );
+                    this.emit('json_error', error.name, error.message);
                     currentTranslations = {};
                 }
             }
@@ -260,33 +273,33 @@ Parser.prototype._flush = function(done) {
 
 
             // merges existing translations with the new ones
-            mergedTranslations = helpers.mergeHash( currentTranslations, translationsHash[namespace], null, this.keepRemoved );
+            mergedTranslations = helpers.mergeHash(currentTranslations, translationsHash[namespace], null, this.keepRemoved);
 
             // restore old translations if the key is empty
-            mergedTranslations.new = helpers.replaceEmpty( oldTranslations, mergedTranslations.new );
+            mergedTranslations.new = helpers.replaceEmpty(oldTranslations, mergedTranslations.new);
 
             // merges former old translations with the new ones
-            mergedTranslations.old = _.extend( oldTranslations, mergedTranslations.old );
+            mergedTranslations.old = _.extend(oldTranslations, mergedTranslations.old);
 
 
 
             // push files back to the stream
             mergedTranslationsFile = new File({
-              path: namespacePath,
-              base: base,
-              contents: new Buffer( JSON.stringify( mergedTranslations.new, null, 2 ) )
+                path: namespacePath,
+                base: base,
+                contents: new Buffer(JSON.stringify(mergedTranslations.new, null, 2))
             });
-            this.emit( 'writing', namespacePath );
-            self.push( mergedTranslationsFile );
+            this.emit('writing', namespacePath);
+            self.push(mergedTranslationsFile);
 
-            if ( self.writeOld ) {
+            if (self.writeOld) {
                 mergedOldTranslationsFile = new File({
                     path: namespaceOldPath,
                     base: base,
                     contents: new Buffer(JSON.stringify(mergedTranslations.old, null, 2))
                 });
-                this.emit( 'writing', namespaceOldPath );
-                self.push( mergedOldTranslationsFile );
+                this.emit('writing', namespaceOldPath);
+                self.push(mergedOldTranslationsFile);
             }
 
 
@@ -298,6 +311,6 @@ Parser.prototype._flush = function(done) {
 
 
 
-module.exports = function(options, transformConfig) {
+module.exports = function (options, transformConfig) {
     return new Parser(options, transformConfig);
 };

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ Parser.prototype._transform = function(file, encoding, done) {
     // and we parse for attributes in html
     // ===================================
     const attributes = '(?:' + this.attributes.join('|') + ')';
-    var attributeWithValueRegex = new RegExp( '(?:\\s+' + attributes + '=")([^"]*)(?:")', 'gi' );
+    var attributeWithValueRegex = new RegExp( '(?:\\W+' + attributes + '=")([^"]*)(?:")', 'gi' );
     var attributeWithoutValueRegex = new RegExp( '<([A-Z][A-Z0-9]*)(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*(?:(?:\\s+' + attributes + '))(?:(?:\\s+[A-Z0-9-]+)(?:(?:=")(?:[^"]*)(?:"))?)*\\s*(?:>(.*?)<\\/\\1>)', 'gi' );
 
     while (( matches = attributeWithValueRegex.exec( fileContent ) )) {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-var gutil = require('gulp-util');
+var gutil       = require('gulp-util');
 var PluginError = gutil.PluginError;
-var Transform = require('stream').Transform;
-var util = require('util');
-var helpers = require('./src/helpers');
-var fs = require('fs');
-var File = require('vinyl');
-var path = require('path');
-var _ = require('lodash');
+var Transform   = require('stream').Transform;
+var util        = require('util');
+var helpers     = require('./src/helpers');
+var fs          = require('fs');
+var File        = require('vinyl');
+var path        = require('path');
+var _           = require('lodash');
 
 
 

--- a/index.js
+++ b/index.js
@@ -21,23 +21,29 @@ function Parser(options, transformConfig) {
     options = options || {};
     transformConfig = transformConfig || {};
 
-    this.defaultNamespace = options.namespace || 'translation';
-    this.functions = options.functions || ['t'];
-    this.locales = options.locales || ['en', 'fr'];
-    this.output = options.output || 'locales';
-    this.regex = options.parser;
-    this.attributes = options.attributes || ['data-i18n'];
-    this.namespaceSeparator = options.namespaceSeparator || ':';
-    this.keySeparator = options.keySeparator || '.';
-    this.contextSeparator = options.contextSeparator || '_';
-    this.translations = [];
-    this.extension = options.extension || '.json';
-    this.suffix = options.suffix || '';
-    this.prefix = options.prefix || '';
-    this.writeOld = options.writeOld !== false;
-    this.keepRemoved = options.keepRemoved;
-    this.ignoreVariables = options.ignoreVariables || false;
-    this.includeSingleQuoted = options.includeSingleQuoted || false;
+    this.defaultNamespace       = options.namespace || 'translation';
+    this.functions              = options.functions || ['t'];
+    this.locales                = options.locales || ['en','fr'];
+    this.output                 = options.output || 'locales';
+    this.regex                  = options.parser;
+    this.attributes             = options.attributes || ['data-i18n'];
+    this.defaultNamespace       = options.namespace || 'translation';
+    this.functions              = options.functions || ['t'];
+    this.locales                = options.locales || ['en', 'fr'];
+    this.output                 = options.output || 'locales';
+    this.regex                  = options.parser;
+    this.attributes             = options.attributes || ['data-i18n'];
+    this.namespaceSeparator     = options.namespaceSeparator || ':';
+    this.keySeparator           = options.keySeparator || '.';
+    this.contextSeparator       = options.contextSeparator || '_';
+    this.translations           = [];
+    this.extension              = options.extension || '.json';
+    this.suffix                 = options.suffix || '';
+    this.prefix                 = options.prefix || '';
+    this.writeOld               = options.writeOld !== false;
+    this.keepRemoved            = options.keepRemoved;
+    this.ignoreVariables        = options.ignoreVariables || false;
+    this.includeSingleQuoted    = options.includeSingleQuoted || false;
 
     ['functions', 'locales'].forEach(function (attr) {
         if ((typeof self[attr] !== 'object') || !self[attr].length) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -11,12 +11,12 @@ var replaceEmpty    = helpers.replaceEmpty
 
 describe('parser', function () {
 
-    function isFilenameMatch(firstFile,secondFile){
+    function isFilenameMatch(firstFile,secondFile) {
         return (firstFile === secondFile) || firstFile.replace('\\','/') === secondFile.replace('\\','/');
     }
 
-    function isFilenameInArray(filename,filenameArray){
-        return (filenameArray.indexOf(filename)>-1) || filenameArray.map(function(fn){return fn.replace('\\','/')}).indexOf(filename.replace('\\','/'))>-1;
+    function isFilenameInArray(filename,filenameArray) {
+        return (filenameArray.indexOf(filename)>-1) || filenameArray.map(function(fn) {return fn.replace('\\','/')}).indexOf(filename.replace('\\','/'))>-1;
     }
 
 
@@ -28,7 +28,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -52,7 +52,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -72,7 +72,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -93,7 +93,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -117,7 +117,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -142,7 +142,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -164,7 +164,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -287,7 +287,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/test_separators.json')){
+            if (isFilenameMatch(file.relative,'en/test_separators.json')) {
             //if ( file.relative === 'en/test_separators.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -309,7 +309,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -333,7 +333,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -356,7 +356,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -397,7 +397,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/test_merge.json')){
+            if (isFilenameMatch(file.relative,'en/test_merge.json')) {
             //if ( file.relative === 'en/test_merge.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -424,7 +424,7 @@ describe('parser', function () {
         };
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/test_context.json')){
+            if (isFilenameMatch(file.relative,'en/test_context.json')) {
             //if ( file.relative === 'en/test_context.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -453,7 +453,7 @@ describe('parser', function () {
         };
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/test_plural.json')){
+            if (isFilenameMatch(file.relative,'en/test_plural.json')) {
             //if ( file.relative === 'en/test_plural.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -480,7 +480,7 @@ describe('parser', function () {
         };
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/test_context_plural.json')){
+            if (isFilenameMatch(file.relative,'en/test_context_plural.json')) {
             //if ( file.relative === 'en/test_context_plural.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -501,7 +501,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -536,7 +536,7 @@ describe('parser', function () {
             contents: new Buffer("// FIX this doesn't work and this t is all alone\nt('first')\nt = function() {}")
         });
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
@@ -556,7 +556,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if (isFilenameMatch(file.relative,'en/translation.json')){
+            if (isFilenameMatch(file.relative,'en/translation.json')) {
             //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }

--- a/test/parser.js
+++ b/test/parser.js
@@ -134,7 +134,7 @@ describe('parser', function () {
         var result;
         var i18nextParser = Parser({
             attributes:['t'],
-            includeSingleQuoted : false
+            includeSingleQuoted : true
         });
 
         var fakeFile = new File({

--- a/test/parser.js
+++ b/test/parser.js
@@ -133,7 +133,8 @@ describe('parser', function () {
     it('parses jade attributes with single quotes', function (done) {
         var result;
         var i18nextParser = Parser({
-            attributes:['t']
+            attributes:['t'],
+            includeSingleQuoted : false
         });
 
         var fakeFile = new File({

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,4 +1,25 @@
+var fs              = require('fs');
+var path            = require('path');
+var assert          = require('assert');
+var File            = require('vinyl');
+var through         = require('through2');
+var Parser          = require('../index');
+var helpers         = require('../src/helpers');
+var hashFromString  = helpers.hashFromString;
+var mergeHash       = helpers.mergeHash;
+var replaceEmpty    = helpers.replaceEmpty
+
 describe('parser', function () {
+
+    function isFilenameMatch(firstFile,secondFile){
+        return (firstFile === secondFile) || firstFile.replace('\\','/') === secondFile.replace('\\','/');
+    }
+
+    function isFilenameInArray(filename,filenameArray){
+        return (filenameArray.indexOf(filename)>-1) || filenameArray.map(function(fn){return fn.replace('\\','/')}).indexOf(filename.replace('\\','/'))>-1;
+    }
+
+
     it('parses globally on multiple lines', function (done) {
         var result;
         var i18nextParser = Parser();
@@ -7,7 +28,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -30,7 +52,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -49,7 +72,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -69,12 +93,61 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
         i18nextParser.on('end', function (file) {
             assert.deepEqual( result, { first: '' } );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
+    it('parses jade templates with attributes', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            attributes:['t']
+        });
+
+        var fakeFile = new File({
+            contents: fs.readFileSync( path.resolve(__dirname, 'templating/jadeattribute-double.jade') )
+        });
+
+        i18nextParser.on('data', function (file) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            assert.deepEqual( result, { first: '', second:'', third:'',fourth : '' } );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
+    it('parses jade attributes with single quotes', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            attributes:['t']
+        });
+
+        var fakeFile = new File({
+            contents: fs.readFileSync( path.resolve(__dirname, 'templating/jadeattribute-single.jade') )
+        });
+
+        i18nextParser.on('data', function (file) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            assert.deepEqual( result, { first: '', second:'', third:'',fourth : '' } );
             done();
         });
 
@@ -90,7 +163,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -126,7 +200,8 @@ describe('parser', function () {
             var length = expectedFiles.length;
 
             expectedFiles.forEach(function (filename) {
-                assert( results.indexOf( filename ) !== -1 );
+                assert(isFilenameInArray(filename,results));
+                //assert( results.indexOf( filename ) !== -1 );                
                 if( ! --length ) done();
             });
         });
@@ -158,7 +233,8 @@ describe('parser', function () {
             var length = expectedFiles.length;
 
             expectedFiles.forEach(function (filename) {
-                assert( results.indexOf( filename ) !== -1 );
+                assert(isFilenameInArray(filename,results));
+                //assert( results.indexOf( filename ) !== -1 );
                 if( ! --length ) done();
             });
         });
@@ -189,7 +265,8 @@ describe('parser', function () {
             var length = expectedFiles.length;
 
             expectedFiles.forEach(function (filename) {
-                assert( results.indexOf( filename ) !== -1 );
+                assert(isFilenameInArray(filename,results));
+                //assert( results.indexOf( filename ) !== -1 );
                 if( ! --length ) done();
             });
         });
@@ -209,7 +286,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/test_separators.json' ) {
+            if (isFilenameMatch(file.relative,'en/test_separators.json')){
+            //if ( file.relative === 'en/test_separators.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -230,7 +308,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -253,7 +332,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -275,7 +355,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -315,7 +396,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/test_merge.json' ) {
+            if (isFilenameMatch(file.relative,'en/test_merge.json')){
+            //if ( file.relative === 'en/test_merge.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -341,7 +423,8 @@ describe('parser', function () {
         };
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/test_context.json' ) {
+            if (isFilenameMatch(file.relative,'en/test_context.json')){
+            //if ( file.relative === 'en/test_context.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -369,7 +452,8 @@ describe('parser', function () {
         };
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/test_plural.json' ) {
+            if (isFilenameMatch(file.relative,'en/test_plural.json')){
+            //if ( file.relative === 'en/test_plural.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -395,7 +479,8 @@ describe('parser', function () {
         };
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/test_context_plural.json' ) {
+            if (isFilenameMatch(file.relative,'en/test_context_plural.json')){
+            //if ( file.relative === 'en/test_context_plural.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -415,7 +500,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -449,7 +535,8 @@ describe('parser', function () {
             contents: new Buffer("// FIX this doesn't work and this t is all alone\nt('first')\nt = function() {}")
         });
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -468,7 +555,8 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if (isFilenameMatch(file.relative,'en/translation.json')){
+            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });

--- a/test/parser.js
+++ b/test/parser.js
@@ -29,7 +29,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -53,7 +52,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -73,7 +71,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -94,7 +91,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -118,7 +114,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -143,7 +138,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -165,7 +159,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -202,7 +195,6 @@ describe('parser', function () {
 
             expectedFiles.forEach(function (filename) {
                 assert(isFilenameInArray(filename,results));
-                //assert( results.indexOf( filename ) !== -1 );                
                 if( ! --length ) done();
             });
         });
@@ -235,7 +227,6 @@ describe('parser', function () {
 
             expectedFiles.forEach(function (filename) {
                 assert(isFilenameInArray(filename,results));
-                //assert( results.indexOf( filename ) !== -1 );
                 if( ! --length ) done();
             });
         });
@@ -267,7 +258,6 @@ describe('parser', function () {
 
             expectedFiles.forEach(function (filename) {
                 assert(isFilenameInArray(filename,results));
-                //assert( results.indexOf( filename ) !== -1 );
                 if( ! --length ) done();
             });
         });
@@ -288,7 +278,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/test_separators.json')) {
-            //if ( file.relative === 'en/test_separators.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -310,7 +299,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -334,7 +322,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -357,7 +344,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -398,7 +384,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/test_merge.json')) {
-            //if ( file.relative === 'en/test_merge.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -425,7 +410,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/test_context.json')) {
-            //if ( file.relative === 'en/test_context.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -454,7 +438,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/test_plural.json')) {
-            //if ( file.relative === 'en/test_plural.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -481,7 +464,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/test_context_plural.json')) {
-            //if ( file.relative === 'en/test_context_plural.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -502,7 +484,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -537,7 +518,6 @@ describe('parser', function () {
         });
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -557,7 +537,6 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if (isFilenameMatch(file.relative,'en/translation.json')) {
-            //if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });

--- a/test/templating/jadeattribute-double.jade
+++ b/test/templating/jadeattribute-double.jade
@@ -1,0 +1,5 @@
+div.foobar( t="first")
+div.foobar(t="second")
+div.foobar(data-x="x",t="third")
+div.foobar(data-x="x", t="fourth")
+

--- a/test/templating/jadeattribute-single.jade
+++ b/test/templating/jadeattribute-single.jade
@@ -1,0 +1,5 @@
+div.foobar( t='first')
+div.foobar(t='second')
+div.foobar(data-x='x',t='third')
+div.foobar(data-x='x', t='fourth')
+


### PR DESCRIPTION
In this PR 
- a fix for issue 50 : in jade file attributes preceded with ( are not matched
- a fix for single quotes attributes not being parsed, added a new option 'includeSingleQuoted' that enables this fix
- changes in test/parser.js in order to run test on the windows platform
- added 2 tests in parser.js to test both fixes
