### PR TITLE
Fix pattern: ignore functions which terminate with a 't'

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ Parser.prototype._transform = function(file, encoding, done) {
     var doubleQuotePattern = '"([^\"].*?[^\\\\])?"';
     var backQuotePattern   = '`([^\`].*?[^\\\\])?`';
     var stringPattern = '(?:' + singleQuotePattern + '|' + doubleQuotePattern + '|' + backQuotePattern + ')';
-    var pattern = '.*?(?:' + fnPattern + ')\\s*\\(?\\s*' + stringPattern + '(?:(?:[^).]*?)\\{(?:.*?)(?:(?:context|\'context\'|"context")\\s*:\\s*' + stringPattern + '(?:.*?)\\}))?';
+    var pattern = '(?:\\W|^)(?:' + fnPattern + ')\\s*\\(?\\s*' + stringPattern + '(?:(?:[^).]*?)\\{(?:.*?)(?:(?:context|\'context\'|"context")\\s*:\\s*' + stringPattern + '(?:.*?)\\}))?';
 
     var functionRegex = new RegExp( this.regex || pattern, 'g' );
     while (( matches = functionRegex.exec( fileContent ) )) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -478,4 +478,23 @@ describe('parser', function () {
         });
         i18nextParser.end(fakeFile);
     });
+
+    it('ignore other string with a t', function (done) {
+        var result;
+        var i18nextParser = Parser();
+        var fakeFile = new File({
+            contents: new Buffer('import \'./yolo.js\'; t(\'first\');')
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            assert.deepEqual( result, { first: '' });
+            done();
+        });
+        i18nextParser.end(fakeFile);
+    });
 });


### PR DESCRIPTION
Atm, we look for something like:
(anything)t(spaces or nothing)(a `(` or nothing)...
Sadly, if we have `import './lol.scss';` it will be detected as a translation (`t 'lol.scss'`)

For fix, I added a check on the previous char:
(start of the line or anything except [a-zA-Z0-9_])t(spaces or nothing)(a `(` or nothing)...

Now it works.