### PR TITLE
Add --track-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ npm install i18next-parser -g
 ## Tests
 
 ```
+npm install -g mocha
 mocha --reporter nyan test/test.js
+```
+or
+```
+npm test
 ```
 
 ---

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,6 +26,7 @@ program
   .option( '-k, --key-separator <string>'        , 'The default key separator (. by default)' )
   .option( '-c, --context-separator <string>'    , 'The default context separator (_ by default)' )
   .option( '-l, --locales <list>'                , 'The locales in your application' )
+  .option( '-t, --track-paths <boolean>'         , 'Output an additional file with file paths for each key' )
   .option( '--directoryFilter <list>'            , 'Filter directories' )
   .option( '--fileFilter <list>'                 , 'Filter files' )
   .option( '--keep-removed'                      , 'Prevent keys no longer found from being removed' )
@@ -74,6 +75,7 @@ program.writeOld = program.writeOld !== 'false';
 program.directoryFilter = program.directoryFilter && program.directoryFilter.split(',');
 program.fileFilter = program.fileFilter && program.fileFilter.split(',');
 program.output = path.resolve(process.cwd(), output);
+program.trackPaths = program.trackPaths === 'true' || program.trackPaths;
 
 
 

--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ Parser.prototype._flush = function(done) {
                 }
                 catch (error) {
                     this.emit( 'json_error', error.name, error.message );
-                    currentTranslations = {};
+                    oldTranslations = {};
                 }
             }
             else {

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function Parser(options, transformConfig) {
     this.writeOld           = options.writeOld !== false;
     this.keepRemoved        = options.keepRemoved;
     this.ignoreVariables    = options.ignoreVariables || false;
+    this.trackPaths         = options.trackPaths || false;
 
     ['functions', 'locales'].forEach(function( attr ) {
         if ( (typeof self[ attr ] !== 'object') || ! self[ attr ].length ) {
@@ -88,6 +89,15 @@ Parser.prototype._transform = function(file, encoding, done) {
     // =================
     if(file.isBuffer()) {
         data = file.contents;
+    }
+
+
+
+    // we find the relative path
+    // =========================
+    var relativeFilePath = path.relative(__dirname, this.base);
+    if (file.path) {
+        relativeFilePath = path.relative(process.cwd(), file.path);
     }
 
 
@@ -176,7 +186,10 @@ Parser.prototype._transform = function(file, encoding, done) {
             key = key.replace( self.namespaceSeparator, self.keySeparator );
         }
 
-        self.translations.push( key );
+        self.translations.push({
+            'key': key,
+            'paths': [relativeFilePath]
+        });
     }
 
     done();
@@ -189,21 +202,57 @@ Parser.prototype._flush = function(done) {
     var self = this;
     var base = path.resolve( self.base, self.output );
     var translationsHash = {};
+    var translationsHashCommented = {};
 
 
+
+    // merge file paths
+    // ================
+    var tempHash = {};
+    _.map(self.translations, (_, index) => {
+        var translation = self.translations[index];
+
+        if (tempHash.hasOwnProperty(translation.key)) {
+            tempHash[translation.key] = tempHash[translation.key].concat(translation.paths);
+        } else {
+            tempHash[translation.key] = translation.paths;
+        }
+
+        // keep file paths in predictable order
+        tempHash[translation.key].sort();
+
+        return _;
+    });
 
     // remove duplicate keys
     // =====================
-    self.translations = _.uniq( self.translations ).sort();
+    self.translations = _.map(tempHash, (paths, key) => {
+        return { key: key, paths: paths};
+    });
+
+    // sort by key
+    // ===========
+    self.translations = _.sortBy(self.translations, 'key' );
 
 
 
-    // turn the array of keys
+    // turn the array of objects
     // into an associative object
     // ==========================
+    // from
+    // [{ keyOne: '', paths: ['', '']}, { keyTwo: '', paths: ['']}]
+    // to
+    // { 'keyOne': { msgstr: '', paths: ['', ''] }, keyTwo: { msgstr: '', paths: [''] } }
+    // ==================================================================================
     for (var index in self.translations) {
         // simplify ${dot.separated.variables} into just their tails (${variables})
-        var key = self.translations[index].replace( /\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}' );
+        var key = self.translations[index].key.replace( /\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}' ),
+            paths = self.translations[index].paths;
+
+        if (self.trackPaths) {
+            translationsHashCommented = helpers.hashFromString( key, self.keySeparator, translationsHashCommented, paths );
+        }
+
         translationsHash = helpers.hashFromString( key, self.keySeparator, translationsHash );
     }
 
@@ -289,7 +338,26 @@ Parser.prototype._flush = function(done) {
                 self.push( mergedOldTranslationsFile );
             }
 
+            if ( self.trackPaths ) {
+                var namespacePathCommented = path.resolve(
+                    localeBase,
+                    prefix + namespace + suffix + '.po' + extension
+                );
 
+                // merges existing translations with the new commented ones
+                mergedTranslationsCommented = helpers.mergeHash( currentTranslations, translationsHashCommented[namespace], null, this.keepRemoved );
+
+                // restore old translations if the key is empty
+                mergedTranslationsCommented.new = helpers.replaceEmpty( oldTranslations, mergedTranslationsCommented.new );
+
+                mergedTranslationsFileCommented = new File({
+                  path: namespacePathCommented,
+                  base: base,
+                  contents: new Buffer( JSON.stringify( mergedTranslationsCommented.new, null, 2 ) )
+                });
+                this.emit( 'writing', namespacePathCommented );
+                self.push( mergedTranslationsFileCommented );
+            }
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "i18next": "./bin/cli.js"
   },
+  "scripts": {
+    "test": "mocha --reporter nyan test/test.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/i18next/i18next-parser"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,12 +9,40 @@ describe('mergeHash helper function', function () {
         done();
     });
 
+    it('replaces `target` keys with `source` while tracking paths', function (done) {
+        var source = { key1: 'value1' };
+        var target = { key1: simpleDeepCopy(emptyTranslationWithPaths) };
+        var res    = mergeHash(source, target);
+
+        assert.deepEqual(res.new, { key1: { msgstr: 'value1', paths: [''] } });
+        assert.deepEqual(res.old, {});
+        done();
+    });
+
     it('leaves untouched `target` keys not in `source`', function (done) {
         var source = { key1: 'value1' };
         var target = { key1: '', key2: '' };
         var res    = mergeHash(source, target);
 
         assert.deepEqual(res.new, { key1: 'value1', key2: '' });
+        assert.deepEqual(res.old, {});
+        done();
+    });
+
+    it('leaves untouched `target` keys not in `source` while tracking paths', function (done) {
+        var translationValue = simpleDeepCopy(emptyTranslationWithPaths);
+        var source = { key1: 'value1' };
+        var target = {
+            key1: translationValue,
+            key2: translationValue
+        };
+        var res = mergeHash(source, target);
+        var expected = {
+            key1: { msgstr: 'value1', paths: [''] },
+            key2: translationValue
+        };
+
+        assert.deepEqual(res.new, expected);
         assert.deepEqual(res.old, {});
         done();
     });
@@ -29,12 +57,36 @@ describe('mergeHash helper function', function () {
         done();
     });
 
+    it('populates `old` object with keys from `source` not in `target` while tracking paths', function (done) {
+        var source = { key1: 'value1', key2: 'value2' };
+        var target = { key1: simpleDeepCopy(emptyTranslationWithPaths) };
+        var res    = mergeHash(source, target);
+
+        assert.deepEqual(res.new, { key1: { msgstr: 'value1', paths: [''] } });
+        assert.deepEqual(res.old, { key2: 'value2' });
+        done();
+    });
+
     it('copies `source` keys to `target` regardless of presence when keepRemoved is enabled', function (done) {
         var source = { key1: 'value1', key2: 'value2' };
         var target = { key1: '', key3: '' };
         var res    = mergeHash(source, target, null, true);
 
         assert.deepEqual(res.new, { key1: 'value1', key2: 'value2', key3: '' });
+        assert.deepEqual(res.old, { key2: 'value2' });
+        done();
+    });
+
+    it('copies `source` keys to `target` regardless of presence when keepRemoved is enabled while tracking paths', function (done) {
+        var source = { key1: 'value1', key2: 'value2' };
+        var target = { key1: simpleDeepCopy(emptyTranslationWithPaths), key3: simpleDeepCopy(emptyTranslationWithPaths) };
+        var res    = mergeHash(source, target, null, true);
+
+        assert.deepEqual(res.new, {
+            key1: { msgstr: 'value1', paths: [''] },
+            key2: 'value2',
+            key3: simpleDeepCopy(emptyTranslationWithPaths)
+        });
         assert.deepEqual(res.old, { key2: 'value2' });
         done();
     });
@@ -49,12 +101,33 @@ describe('mergeHash helper function', function () {
         done();
     });
 
+    it('restores plural keys when the singular one exists while tracking paths', function (done) {
+        var translationValue = simpleDeepCopy(emptyTranslationWithPaths);
+        var source = { key1: '', key1_plural: 'value1' };
+        var target = { key1: translationValue };
+        var res    = mergeHash(source, target);
+
+        assert.deepEqual(res.new, { key1: translationValue, key1_plural: 'value1' });
+        assert.deepEqual(res.old, {});
+        done();
+    });
+
     it('does not restores plural keys when the singular one does not', function (done) {
         var source = { key1: '', key1_plural: 'value1' };
         var target = { key2: '' };
         var res    = mergeHash(source, target);
 
         assert.deepEqual(res.new, { key2: '' });
+        assert.deepEqual(res.old, { key1: '', key1_plural: 'value1' });
+        done();
+    });
+
+    it('does not restores plural keys when the singular one does not, while tracking paths', function (done) {
+        var source = { key1: '', key1_plural: 'value1' };
+        var target = { key2: simpleDeepCopy(emptyTranslationWithPaths) };
+        var res    = mergeHash(source, target);
+
+        assert.deepEqual(res.new, { key2: simpleDeepCopy(emptyTranslationWithPaths) });
         assert.deepEqual(res.old, { key1: '', key1_plural: 'value1' });
         done();
     });
@@ -113,12 +186,82 @@ describe('mergeHash helper function', function () {
         done();
     });
 
+    it('works with deep objects and file path tracking', function (done) {
+        var valueOne = simpleDeepCopy(emptyTranslationWithPaths);
+        var valueTwoOne = simpleDeepCopy(emptyTranslationWithPaths);
+        var valueTwoTwoTwo = simpleDeepCopy(emptyTranslationWithPaths);
+        valueOne.msgstr = 'value1';
+        valueTwoOne.msgstr = 'value21';
+        valueTwoTwoTwo.msgstr = 'value222';
+
+        var source = {
+            key1: 'value1',
+            key2: {
+                key21: 'value21',
+                key22: {
+                    key221: 'value221',
+                    key222: 'value222'
+                },
+                key23: 'value23'
+            }
+        };
+        var target = {
+            key1: simpleDeepCopy(emptyTranslationWithPaths),
+            key2: {
+                key21: simpleDeepCopy(emptyTranslationWithPaths),
+                key22: {
+                    key222: simpleDeepCopy(emptyTranslationWithPaths),
+                    key223: simpleDeepCopy(emptyTranslationWithPaths)
+                },
+                key24: simpleDeepCopy(emptyTranslationWithPaths)
+            },
+            key3: simpleDeepCopy(emptyTranslationWithPaths)
+        };
+
+        var res = mergeHash(source, target);
+
+        var expected_target = {
+            key1: valueOne,
+            key2: {
+                key21: valueTwoOne,
+                key22: {
+                    key222: valueTwoTwoTwo,
+                    key223: simpleDeepCopy(emptyTranslationWithPaths)
+                },
+                key24: simpleDeepCopy(emptyTranslationWithPaths)
+            },
+            key3: simpleDeepCopy(emptyTranslationWithPaths)
+        };
+
+        var expected_old = {
+            key2: {
+                key22: {
+                    key221: 'value221'
+                },
+                key23: 'value23'
+            }
+        };
+
+        assert.deepEqual(res.new, expected_target);
+        assert.deepEqual(res.old, expected_old);
+        done();
+    });
+
     it('leaves arrays of values (multiline) untouched', function (done) {
         var source = { key1: ['Line one.', 'Line two.'] };
         var target = { key1: '' };
         var res    = mergeHash(source, target);
 
         assert.deepEqual(res.new, { key1: ['Line one.', 'Line two.'] });
+        done();
+    });
+
+    it('leaves arrays of values (multiline) untouched while tracking paths', function (done) {
+        var source = { key1: ['Line one.', 'Line two.'] };
+        var target = { key1: simpleDeepCopy(emptyTranslationWithPaths) };
+        var res    = mergeHash(source, target);
+
+        assert.deepEqual(res.new, { key1: { msgstr: ['Line one.', 'Line two.'], paths: [''] } });
         done();
     });
 });
@@ -132,10 +275,24 @@ describe('hashFromString helper function', function () {
         done();
     });
 
+    it('creates an object from a string path while tracking file paths', function (done) {
+        var res = hashFromString('one', null, null, ['testing/a/path']);
+
+        assert.deepEqual(res, { one: { msgstr: '', paths: ['testing/a/path'] } });
+        done();
+    });
+
     it('ignores trailing separator', function (done) {
         var res = hashFromString('one..', '..');
 
         assert.deepEqual(res, { one: '' });
+        done();
+    });
+
+    it('ignores trailing separator while tracking paths', function (done) {
+        var res = hashFromString('one..', '..', null, ['file/location.html']);
+
+        assert.deepEqual(res, { one: { msgstr: '', paths: ['file/location.html'] } });
         done();
     });
 
@@ -146,10 +303,40 @@ describe('hashFromString helper function', function () {
         done();
     });
 
+    it('handles nested paths while tracking file paths', function (done) {
+        var res = hashFromString('one.two.three', null, null, ['./one/two/three.js']);
+
+        assert.deepEqual(res, {
+            one: {
+                two: {
+                    msgstr: '',
+                    paths: ['./one/two/three.js'],
+                    three: { msgstr: '', paths: ['./one/two/three.js']}
+                }
+            }
+        });
+        done();
+    });
+
     it('handles a different separator', function (done) {
         var res = hashFromString('one_two_three.', '_');
 
         assert.deepEqual(res, { one: { two: { 'three.': '' } } });
+        done();
+    });
+
+    it('handles a different separator while tracking paths', function (done) {
+        var res = hashFromString('one_two_three.', '_', null, ['./one/two/three.js']);
+
+        assert.deepEqual(res, {
+            one: {
+                two: {
+                    msgstr: '',
+                    paths: ['./one/two/three.js'],
+                    'three.': { msgstr: '', paths: ['./one/two/three.js']}
+                }
+            }
+        });
         done();
     });
 });

--- a/test/parser.js
+++ b/test/parser.js
@@ -19,7 +19,6 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
-
     it('parses attributes in html templates', function (done) {
         var result;
         var i18nextParser = Parser({
@@ -57,6 +56,7 @@ describe('parser', function () {
             assert.deepEqual( result, { first: '', second: '', third: '', fourth: '', fifth: '' } );
             done();
         });
+
         i18nextParser.end(fakeFile);
     });
 
@@ -214,6 +214,7 @@ describe('parser', function () {
             }
         });
         i18nextParser.once('end', function (file) {
+
             assert.deepEqual( result, { first: '', second: { third: '' } } );
             done();
         });
@@ -235,9 +236,11 @@ describe('parser', function () {
             }
         });
         i18nextParser.once('end', function (file) {
-            var keys = Object.keys(result);
-            assert.equal( keys[0], 'escaped "double quotes"' );
-            assert.equal( keys[1], "escaped 'single quotes'" );
+            var expectedResult = {
+                "escaped 'single quotes'": '',
+                'escaped "double quotes"': ''
+            };
+            assert.deepEqual( result, expectedResult );
             done();
         });
 
@@ -308,6 +311,7 @@ describe('parser', function () {
     });
 
     it('retrieves values in existing file', function (done) {
+        var result;
         var i18nextParser = Parser();
         var fakeFile = new File({
             base: __dirname,
@@ -328,6 +332,7 @@ describe('parser', function () {
     });
 
     it('retrieves context values in existing file', function (done) {
+        var result;
         var i18nextParser = Parser();
         var fakeFile = new File({
             base: __dirname,
@@ -354,6 +359,7 @@ describe('parser', function () {
     });
 
     it('retrieves plural values in existing file', function (done) {
+        var result;
         var i18nextParser = Parser();
         var fakeFile = new File({
             base: __dirname,
@@ -382,6 +388,7 @@ describe('parser', function () {
     });
 
     it('retrieves plural and context values in existing file', function (done) {
+        var result;
         var i18nextParser = Parser();
         var fakeFile = new File({
             base: __dirname,
@@ -448,6 +455,7 @@ describe('parser', function () {
         var fakeFile = new File({
             contents: new Buffer("// FIX this doesn't work and this t is all alone\nt('first')\nt = function() {}")
         });
+
         i18nextParser.on('data', function (file) {
             if ( file.relative === 'en/translation.json' ) {
                 result = JSON.parse( file.contents );
@@ -457,6 +465,7 @@ describe('parser', function () {
             assert.deepEqual( result, {first: ''} );
             done();
         });
+
         i18nextParser.end(fakeFile);
     });
 
@@ -479,7 +488,7 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
-    it('ignores functions that ends with a t', function (done) {
+    it('ignores functions that end with a t', function (done) {
         var result;
         var i18nextParser = Parser();
         var fakeFile = new File({
@@ -495,6 +504,7 @@ describe('parser', function () {
             assert.deepEqual( result, { first: '' });
             done();
         });
+
         i18nextParser.end(fakeFile);
     });
 });

--- a/test/parser.js
+++ b/test/parser.js
@@ -37,6 +37,36 @@ describe('parser', function () {
             assert.deepEqual( result, { first: '', second: '', third: '', fourth: '', fifth: '' } );
             done();
         });
+
+        i18nextParser.end(fakeFile);
+    });
+
+    it('parses attributes in html templates and tracks paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+          attributes: ['data-i18n', 'translate', 't'],
+          trackPaths: true
+        });
+        var fakeFile = new File({
+            contents: new Buffer('<p data-i18n>first</p><p translate="second">Second</p><p t="[html]third">Third</p><p data-i18n="[title]fourth;fifth">Fifth</p>')
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            assert.deepEqual( result, {
+                first: emptyTranslationWithPaths,
+                second: emptyTranslationWithPaths,
+                third: emptyTranslationWithPaths,
+                fourth: emptyTranslationWithPaths,
+                fifth: emptyTranslationWithPaths
+            });
+            done();
+        });
+
         i18nextParser.end(fakeFile);
     });
 
@@ -60,6 +90,39 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('parses html templates and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            base: path.resolve(__dirname, 'templating/html.html'),
+            contents: fs.readFileSync( path.resolve(__dirname, 'templating/html.html') )
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            var translationWithPaths = simpleDeepCopy( emptyTranslationWithPaths );
+
+            translationWithPaths.paths = ['test/templating/html.html'];
+
+            assert.deepEqual( result, {
+                first: translationWithPaths,
+                second: translationWithPaths,
+                third: translationWithPaths,
+                fourth: translationWithPaths,
+                fifth: translationWithPaths
+            });
+
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
 
     it('parses jade templates', function (done) {
         var result;
@@ -81,6 +144,32 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('parses jade templates and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            base: path.resolve(__dirname, 'templating/jade.jade'),
+            contents: fs.readFileSync( path.resolve(__dirname, 'templating/jade.jade') )
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            var translationWithPaths = simpleDeepCopy( emptyTranslationWithPaths );
+
+            translationWithPaths.paths = ['test/templating/jade.jade'];
+
+            assert.deepEqual( result, { first: translationWithPaths });
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
 
     it('parses handlebars templates', function (done) {
         var result;
@@ -102,6 +191,32 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('parses handlebars templates and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            base: path.resolve(__dirname, 'templating/handlebars.hbs'),
+            contents: fs.readFileSync( path.resolve(__dirname, 'templating/handlebars.hbs') )
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            var translationWithPaths = simpleDeepCopy( emptyTranslationWithPaths );
+
+            translationWithPaths.paths = ['test/templating/handlebars.hbs'];
+
+            assert.deepEqual( result, { first: translationWithPaths } );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
 
     it('creates two files per namespace and per locale', function (done) {
         var results = [];
@@ -129,6 +244,66 @@ describe('parser', function () {
                 assert( results.indexOf( filename ) !== -1 );
                 if( ! --length ) done();
             });
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
+    it('creates three files per namespace and per locale while tracking paths', function (done) {
+        var results = [];
+        var resultContents = [];
+        var i18nextParser = Parser({
+            locales: ['en', 'de', 'fr'],
+            namespace: 'default',
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            contents: new Buffer("asd t('ns1:first') t('second') \n asd t('ns2:third') ad t('fourth')")
+        });
+
+        i18nextParser.on('data', function (file) {
+            results.push( file.relative );
+
+            if (/\.po\.json$/.test(file.relative)) {
+                resultContents.push(JSON.parse( file.contents ));
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            var expectedFiles = [
+                'en/default.json', 'en/default.po.json', 'en/default_old.json',
+                'en/ns1.json', 'en/ns1.po.json', 'en/ns1_old.json',
+                'en/ns2.json', 'en/ns2.po.json', 'en/ns2_old.json',
+                'de/default.json', 'de/default.po.json', 'de/default_old.json',
+                'de/ns1.json', 'de/ns1.po.json', 'de/ns1_old.json',
+                'de/ns2.json', 'de/ns2.po.json', 'de/ns2_old.json',
+                'fr/default.json', 'fr/default.po.json', 'fr/default_old.json',
+                'fr/ns1.json', 'fr/ns1.po.json', 'fr/ns1_old.json',
+                'fr/ns2.json', 'fr/ns2.po.json', 'fr/ns2_old.json'
+            ];
+            var length = expectedFiles.length;
+
+            expectedFiles.forEach(function (filename) {
+                assert( results.indexOf( filename ) !== -1 );
+                if( ! --length ) done();
+            });
+
+            var expectedContents = [
+                { fourth: emptyTranslationWithPaths,
+                  second: emptyTranslationWithPaths },
+                { first: emptyTranslationWithPaths },
+                { third: emptyTranslationWithPaths },
+                { fourth: emptyTranslationWithPaths,
+                  second: emptyTranslationWithPaths },
+                { first: emptyTranslationWithPaths },
+                { third: emptyTranslationWithPaths },
+                { fourth: emptyTranslationWithPaths,
+                  second: emptyTranslationWithPaths },
+                { first: emptyTranslationWithPaths },
+                { third: emptyTranslationWithPaths }
+            ];
+
+            assert.deepEqual(resultContents, expectedContents);
+
         });
 
         i18nextParser.end(fakeFile);
@@ -331,6 +506,38 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('retrieves values in existing file and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            base: __dirname,
+            contents: new Buffer("asd t('test_merge:first') t('test_merge:second')")
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/test_merge.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.once('end', function (file) {
+            var translationWithPaths = simpleDeepCopy( emptyTranslationWithPaths );
+            translationWithPaths.paths = ['test'];
+
+            var firstValue = simpleDeepCopy( translationWithPaths );
+            firstValue.msgstr = 'first';
+
+            assert.deepEqual( result, {
+                first: firstValue,
+                second: translationWithPaths,
+            } );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
     it('retrieves context values in existing file', function (done) {
         var result;
         var i18nextParser = Parser();
@@ -347,6 +554,39 @@ describe('parser', function () {
 
         i18nextParser.on('data', function (file) {
             if ( file.relative === 'en/test_context.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.once('end', function (file) {
+            assert.deepEqual( result, expectedResult );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
+    it('retrieves context values in existing file and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            base: __dirname,
+            contents: new Buffer("asd t('test_context:first')")
+        });
+
+        var translationWithPaths = simpleDeepCopy( emptyTranslationWithPaths );
+        translationWithPaths.paths = ['test'];
+        translationWithPaths.msgstr = 'first';
+
+        var expectedResult = {
+            first: translationWithPaths,
+            first_context1: 'first context1',
+            first_context2: ''
+        };
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/test_context.po.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -387,6 +627,45 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('retrieves plural values in existing file and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            base: __dirname,
+            contents: new Buffer("asd t('test_plural:first') t('test_plural:second')")
+        });
+
+        var firstValue = simpleDeepCopy( emptyTranslationWithPaths );
+        firstValue.paths = ['test'];
+        firstValue.msgstr = 'first';
+
+        var secondValue = simpleDeepCopy( emptyTranslationWithPaths );
+        secondValue.paths = ['test'];
+        secondValue.msgstr = 'second';
+
+        var expectedResult = {
+            first: firstValue,
+            first_plural: 'first plural',
+            second: secondValue,
+            second_plural_0: 'second plural 0',
+            second_plural_12: 'second plural 12'
+        };
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/test_plural.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.once('end', function (file) {
+            assert.deepEqual( result, expectedResult );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
     it('retrieves plural and context values in existing file', function (done) {
         var result;
         var i18nextParser = Parser();
@@ -414,6 +693,39 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('retrieves plural and context values in existing file and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            base: __dirname,
+            contents: new Buffer("asd t('test_context_plural:first')")
+        });
+
+        var firstValue = simpleDeepCopy( emptyTranslationWithPaths );
+        firstValue.paths = ['test'];
+        firstValue.msgstr = 'first';
+
+        var expectedResult = {
+            first: firstValue,
+            first_context1_plural: 'first context1 plural',
+            first_context2_plural_2: 'first context2 plural 2'
+        };
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/test_context_plural.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.once('end', function (file) {
+            assert.deepEqual( result, expectedResult );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
     it('removes any trailing [bla] in the key', function (done) {
         var result;
         var i18nextParser = Parser();
@@ -428,6 +740,28 @@ describe('parser', function () {
         });
         i18nextParser.on('end', function (file) {
             assert.deepEqual( result, { first: '' } );
+            done();
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+
+    it('removes any trailing [bla] in the key and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            contents: new Buffer('<p data-i18n="[html]first">!first key!</p>')
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            assert.deepEqual( result, { first: emptyTranslationWithPaths } );
             done();
         });
 
@@ -485,6 +819,34 @@ describe('parser', function () {
             assert.deepEqual( result, { first_date: '', second_form2: '', third_context: '', fourth_pipo: '' } );
             done();
         });
+
+        i18nextParser.end(fakeFile);
+    });
+
+    it('parses context passed as object and tracks file paths', function (done) {
+        var result;
+        var i18nextParser = Parser({
+            trackPaths: true
+        });
+        var fakeFile = new File({
+            contents: new Buffer('t("first", {context: \'date\'}) t("second", { "hello": "world", "context": \'form2\', "foo": "bar"}) t(`third`, { \'context\' : `context` }) t("fourth", { "context" : "pipo"})')
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/translation.po.json' ) {
+                result = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            assert.deepEqual( result, {
+                first_date: emptyTranslationWithPaths,
+                second_form2: emptyTranslationWithPaths,
+                third_context: emptyTranslationWithPaths,
+                fourth_pipo: emptyTranslationWithPaths
+            });
+            done();
+        });
+
         i18nextParser.end(fakeFile);
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,15 @@ var hashFromString  = helpers.hashFromString;
 var mergeHash       = helpers.mergeHash;
 var replaceEmpty    = helpers.replaceEmpty;
 
+var emptyTranslationWithPaths = {
+    'msgstr': '',
+    'paths': ['']
+};
+
+// use with emptyTranslationWithPaths to prevent mutating the original
+function simpleDeepCopy(obj) {
+    return JSON.parse(JSON.stringify(obj));
+}
 
 describe('i18next-parser', function () {
     /* jshint evil:true */


### PR DESCRIPTION
This PR adds the ability to call the parser with `--track-paths true`, resulting in an additional file being output to `prefix + namespace + suffix + '.po' + extension` (ex: locales/en/translation**.po**.json in addition to locales/en/translation.json) with a slightly different format than the original, like so:

```json
// .json
{
    "keyOne": "a value",
}

// .po.json
{
    "keyOne": {
        "msgstr": "a value",
        "paths": ["where/a/value/was/found.html"]
    }
}
```

or with plurals and nested keys:

```json
// .json
{
    "keyOne": {
        "keyTwo": "I have to key",
        "keyTwo_plural": "I have {count} keys",
    }
}

// .po.json
{
    "keyOne": {
        "keyTwo": {
            "msgstr": "I have to key",
            "paths": ["fake/path/index.jade"]
        },
        "keyTwo_plural": "I have {count} keys",
    }
}

```

Additionally, there is a [PR](<PR URL>) up for the gettext-converter to handle both formats when converting from .json -> .po