### PR TITLE
Add test to parse function call on different line

### DIFF
--- a/test/parser.js
+++ b/test/parser.js
@@ -19,6 +19,26 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('parses multiline function calls', function (done) {
+      var result;
+      var i18nextParser = Parser();
+      var fakeFile = new File({
+          contents: new Buffer("asd t(\n  'first'\n) t('second') \n asd t(\n\n'third')")
+      });
+
+      i18nextParser.on('data', function (file) {
+          if ( file.relative === 'en/translation.json' ) {
+              result = JSON.parse( file.contents );
+          }
+      });
+      i18nextParser.on('end', function (file) {
+          assert.deepEqual( result, { first: '', second: '', third: '' } );
+          done();
+      });
+
+      i18nextParser.end(fakeFile);
+    });
+
 
     it('parses attributes in html templates', function (done) {
         var result;


### PR DESCRIPTION
Adds a test for parsing constructs like
```js
const translatedToken = t(
  'some content'
);
```
Which now seems to be supported but nowhere documented.