### PR TITLE
Add license to the package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Command Line tool for i18next",
   "name": "i18next-parser",
   "version": "0.12.0",
+  "license": "MIT",
   "bin": {
     "i18next": "./bin/cli.js"
   },


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.