### PR TITLE
Add --default-values: JS default value extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ node_modules/
 npm-debug.log
 
 # project files
+.idea/

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,6 +34,7 @@ program
   .option( '--keep-removed'                      , 'Prevent keys no longer found from being removed' )
   .option( '--write-old <string>'                , 'Save (or don\'t if false) _old files' )
   .option( '--ignore-variables'                  , 'Don\'t fail when a variable is found' )
+  .option( '--default-values'                    , 'Extract default values' )
   .parse( process.argv );
 
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ function Parser(options, transformConfig) {
     this.writeOld           = options.writeOld !== false;
     this.keepRemoved        = options.keepRemoved;
     this.ignoreVariables    = options.ignoreVariables || false;
+    this.defaultValues      = options.defaultValues || false;
 
     ['functions', 'locales'].forEach(function( attr ) {
         if ( (typeof self[ attr ] !== 'object') || ! self[ attr ].length ) {
@@ -110,6 +111,11 @@ Parser.prototype._transform = function(file, encoding, done) {
     var stringPattern = '(?:' + singleQuotePattern + '|' + doubleQuotePattern + '|' + backQuotePattern + ')';
     var pattern = '(?:\\W|^)(?:' + fnPattern + ')\\s*\\(?\\s*' + stringPattern + '(?:(?:[^).]*?)\\{(?:.*?)(?:(?:context|\'context\'|"context")\\s*:\\s*' + stringPattern + '(?:.*?)\\}))?';
 
+    if (this.defaultValues) {
+        var defaultValuePattern = '(,\\s*{[^}]*defaultValue\\s*:\\s*' + stringPattern + ')?';
+        pattern += defaultValuePattern;
+    }
+
     var functionRegex = new RegExp( this.regex || pattern, 'g' );
     while (( matches = functionRegex.exec( fileContent ) )) {
         var key = matches[1] || matches[2] || matches[3];
@@ -118,7 +124,8 @@ Parser.prototype._transform = function(file, encoding, done) {
             if (context) {
                 key += this.contextSeparator + context;
             }
-            keys.push( key );
+	        var defaultValue = matches[8] || matches[9] || matches[10];
+	        keys.push( { key: key, defaultValue: defaultValue } );
         }
     }
 
@@ -149,19 +156,20 @@ Parser.prototype._transform = function(file, encoding, done) {
 
         for (var i in matchKeys) {
             // remove any leading [] in the key
-            keys.push( matchKeys[i].replace( /^\[[a-zA-Z0-9_-]*\]/ , '' ) );
+            keys.push( { key: matchKeys[i].replace( /^\[[a-zA-Z0-9_-]*\]/ , '' ) } );
         }
     }
 
     while (( matches = attributeWithoutValueRegex.exec( fileContent ) )) {
-        keys.push( matches[2] );
+        keys.push( { key: matches[2] } );
     }
 
 
     // finally we add the parsed keys to the catalog
     // =============================================
     for (var j in keys) {
-        var key = keys[j];
+	    var key = keys[j].key;
+	    var defaultValue = keys[j].defaultValue;
         // remove the backslash from escaped quotes
         key = key.replace(/\\('|"|`)/g, '$1')
         key = key.replace(/\\n/g, '\n');
@@ -176,10 +184,10 @@ Parser.prototype._transform = function(file, encoding, done) {
             key = key.replace( self.namespaceSeparator, self.keySeparator );
         }
 
-        self.translations.push( key );
+        self.translations.push( { key: key, defaultValue: defaultValue } );
     }
 
-    done();
+	done();
 };
 
 
@@ -194,7 +202,13 @@ Parser.prototype._flush = function(done) {
 
     // remove duplicate keys
     // =====================
-    self.translations = _.uniq( self.translations ).sort();
+    function getKey(translation) {
+        return translation.key;
+    }
+    function byKeyOrder(first, second) {
+        return first.key.localeCompare(second.key);
+    }
+    self.translations = _.uniqBy( self.translations, getKey ).sort(byKeyOrder);
 
 
 
@@ -203,8 +217,9 @@ Parser.prototype._flush = function(done) {
     // ==========================
     for (var index in self.translations) {
         // simplify ${dot.separated.variables} into just their tails (${variables})
-        var key = self.translations[index].replace( /\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}' );
-        translationsHash = helpers.hashFromString( key, self.keySeparator, translationsHash );
+        var key = self.translations[index].key.replace( /\$\{(?:[^.}]+\.)*([^}]+)\}/g, '\${$1}' );
+        var value = self.translations[index].defaultValue;
+        translationsHash = helpers.hashFromString( key, self.keySeparator, value, translationsHash );
     }
 
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@
 // turn it into a hash {foo: {bar: ""}}.
 // The generated hash can be attached to an
 // optional `hash`.
-function hashFromString(path, separator, hash) {
+function hashFromString(path, separator, value, hash) {
     separator = separator || '.';
 
     if ( path.indexOf( separator, path.length - separator.length ) >= 0 ) {
@@ -15,7 +15,7 @@ function hashFromString(path, separator, hash) {
 
     for( var x = 0; x < parts.length; x++ ) {
         if ( x == parts.length - 1 ) {
-            tmp_obj[parts[x]] = '';
+            tmp_obj[parts[x]] = value || '';
         }
         else if ( ! tmp_obj[parts[x]] ) {
             tmp_obj[parts[x]] = {};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -123,7 +123,6 @@ describe('mergeHash helper function', function () {
     });
 });
 
-
 describe('hashFromString helper function', function () {
     it('creates an object from a string path', function (done) {
         var res = hashFromString('one');
@@ -136,6 +135,13 @@ describe('hashFromString helper function', function () {
         var res = hashFromString('one..', '..');
 
         assert.deepEqual(res, { one: '' });
+        done();
+    });
+
+    it('use provided default value', function (done) {
+        var res = hashFromString('one', null, 'myDefaultValue');
+
+        assert.deepEqual(res, { one: 'myDefaultValue' });
         done();
     });
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -11,7 +11,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, { first: '', second: '', third: '', fourth: '' } );
             done();
         });
@@ -31,7 +31,7 @@ describe('parser', function () {
               result = JSON.parse( file.contents );
           }
       });
-      i18nextParser.on('end', function (file) {
+      i18nextParser.on('end', function () {
           assert.deepEqual( result, { first: '', second: '', third: '' } );
           done();
       });
@@ -39,6 +39,25 @@ describe('parser', function () {
       i18nextParser.end(fakeFile);
     });
 
+	it('parses default js translations', function (done) {
+		var result;
+		var i18nextParser = Parser({ defaultValues: true });
+		var fakeFile = new File({
+			contents: new Buffer("asd t('first', { defaultValue: 'lol' }) t('second', {defaultValue:\"mdr\"}) \n asd t('third', { other: 'yolo', \ndefaultValue: `ptdr` }) ad t('fourth')")
+		});
+
+		i18nextParser.on('data', function (file) {
+			if ( file.relative === 'en/translation.json' ) {
+				result = JSON.parse( file.contents );
+			}
+		});
+		i18nextParser.on('end', function () {
+			assert.deepEqual( result, { first: 'lol', second: 'mdr', third: 'ptdr', fourth: '' } );
+			done();
+		});
+
+		i18nextParser.end(fakeFile);
+	});
 
     it('parses attributes in html templates', function (done) {
         var result;
@@ -54,7 +73,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, { first: '', second: '', third: '', fourth: '', fifth: '' } );
             done();
         });
@@ -73,13 +92,12 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, { first: '', second: '', third: '', fourth: '', fifth: '' } );
             done();
         });
         i18nextParser.end(fakeFile);
     });
-
 
     it('parses jade templates', function (done) {
         var result;
@@ -93,14 +111,13 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, { first: '' } );
             done();
         });
 
         i18nextParser.end(fakeFile);
     });
-
 
     it('parses handlebars templates', function (done) {
         var result;
@@ -114,14 +131,13 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, { first: '', second: '' } );
             done();
         });
 
         i18nextParser.end(fakeFile);
     });
-
 
     it('creates two files per namespace and per locale', function (done) {
         var results = [];
@@ -136,7 +152,7 @@ describe('parser', function () {
         i18nextParser.on('data', function (file) {
             results.push(file.relative);
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
 
             var expectedFiles = [
                 'en/default.json', 'en/default_old.json', 'en/ns1.json', 'en/ns1_old.json', 'en/ns2.json', 'en/ns2_old.json',
@@ -168,7 +184,7 @@ describe('parser', function () {
         i18nextParser.on('data', function (file) {
             results.push(file.relative);
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
 
             var expectedFiles = [
                 'en/default.json', 'en/ns1.json', 'en/ns2.json',
@@ -202,7 +218,7 @@ describe('parser', function () {
         i18nextParser.on('data', function (file) {
             results.push(file.relative);
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             var expectedFiles = [
                 'en/p-en-default-s-en.en.i18n', 'en/p-en-default-s-en_old.en.i18n'
             ];
@@ -233,7 +249,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.once('end', function (file) {
+        i18nextParser.once('end', function () {
             assert.deepEqual( result, { first: '', second: { third: '' } } );
             done();
         });
@@ -254,10 +270,10 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.once('end', function (file) {
+        i18nextParser.once('end', function () {
             var keys = Object.keys(result);
-            assert.equal( keys[0], 'escaped "double quotes"' );
-            assert.equal( keys[1], "escaped 'single quotes'" );
+            assert.equal( keys[0], "escaped 'single quotes'" );
+            assert.equal( keys[1], 'escaped "double quotes"' );
             done();
         });
 
@@ -277,7 +293,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.once('end', function (file) {
+        i18nextParser.once('end', function () {
             var keys = Object.keys(result);
             assert.equal( keys[0], 'escaped backslash\\ newline\n\r tab\t' );
             done();
@@ -299,8 +315,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.once('end', function (file) {
-            var keys = Object.keys(result);
+        i18nextParser.once('end', function () {
             assert.deepEqual(Object.keys(result), ['root']);
             assert.deepEqual(Object.keys(result.root), [
               '${path}',
@@ -339,7 +354,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.once('end', function (file) {
+        i18nextParser.once('end', function () {
             assert.deepEqual( result, { first: 'first', second: '' } );
             done();
         });
@@ -365,7 +380,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.once('end', function (file) {
+        i18nextParser.once('end', function () {
             assert.deepEqual( result, expectedResult );
             done();
         });
@@ -393,7 +408,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.once('end', function (file) {
+        i18nextParser.once('end', function () {
             assert.deepEqual( result, expectedResult );
             done();
         });
@@ -419,7 +434,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.once('end', function (file) {
+        i18nextParser.once('end', function () {
             assert.deepEqual( result, expectedResult );
             done();
         });
@@ -439,7 +454,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, { first: '' } );
             done();
         });
@@ -473,7 +488,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, {first: ''} );
             done();
         });
@@ -492,7 +507,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, { first_date: '', second_form2: '', third_context: '', fourth_pipo: '' } );
             done();
         });
@@ -511,7 +526,7 @@ describe('parser', function () {
                 result = JSON.parse( file.contents );
             }
         });
-        i18nextParser.on('end', function (file) {
+        i18nextParser.on('end', function () {
             assert.deepEqual( result, { first: '' });
             done();
         });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
i18next offers the ability to pass a default value within the code.
In translation world, the default value (in the default language) is crucial, as it helps to set a context, where only the key can be a technical key.

Extracting the keys is not sufficient in that case, we need to extract the default values too.

**What is the chosen solution to this problem?**
Add an option in cli for retro-compatibility `--default-values`.
When activated, it will parse the javascript code to get the default value from `i18n.t()` arguments, and add them in the generated json file.
