### PR TITLE
Add --react-namespace: parse namespace from react component

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Thanks a lot to all the previous [contributors](https://github.com/i18next/i18ne
 - **--prefix <string>**: Prefix filename for each locale, eg.: 'pre-$LOCALE-' will yield 'pre-en-default.json'
 - **--suffix <string>**: Suffix filename for each locale, eg.: '-$suf-LOCALE' will yield 'default-suf-en.json'
 - **--extension <string>**: Specify extension for filename for each locale, eg.: '.$LOCALE.i18n' will yield 'default.en.i18n'
-
+- **--react-namespace**: when using react-i18next, namespace can be extracted from high order component translate
 ---
 
 ## Gulp Usage

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,6 +25,7 @@ program
   .option( '--suffix <string>'                   , 'Suffix filename for each locale, eg.: \'-$suf-LOCALE\' will yield \'default-suf-en.json\'')
   .option( '--extension <string>'                , 'Specify extension for filename for each locale, eg.: \'.$LOCALE.i18n\' will yield \'default.en.i18n\'')
   .option( '-n, --namespace <string>'            , 'The default namespace (translation by default)' )
+  .option( '--react-namespace'                   , 'Use namespace from translate high order component when using react-i18next (false by default)' )
   .option( '-s, --namespace-separator <string>'  , 'The default namespace separator (: by default)' )
   .option( '-k, --key-separator <string>'        , 'The default key separator (. by default)' )
   .option( '-c, --context-separator <string>'    , 'The default context separator (_ by default)' )

--- a/test/parser.js
+++ b/test/parser.js
@@ -7,7 +7,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -27,7 +27,7 @@ describe('parser', function () {
       });
 
       i18nextParser.on('data', function (file) {
-          if ( file.relative === 'en/translation.json' ) {
+          if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
               result = JSON.parse( file.contents );
           }
       });
@@ -50,7 +50,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -69,7 +69,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -89,7 +89,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -110,7 +110,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -122,6 +122,31 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('parses react templates', function (done) {
+        var commonNs;
+        var specificNs;
+        var i18nextParser = Parser({
+            reactNamespace: true
+        });
+        var fakeFile = new File({
+            contents: fs.readFileSync( path.resolve(__dirname, 'templating/translateHoc.js') )
+        });
+
+        i18nextParser.on('data', function (file) {
+            if ( file.relative === 'en/common.json' || file.relative === 'en\\common.json' ) {
+                commonNs = JSON.parse( file.contents );
+            }
+            if ( file.relative === 'en/specific_namespace.json' || file.relative === 'en\\specific_namespace.json' ) {
+                specificNs = JSON.parse( file.contents );
+            }
+        });
+        i18nextParser.on('end', function (file) {
+            assert.deepEqual( commonNs, { "hello_common": "" } );
+            assert.deepEqual( specificNs, { "hello_specific": "" } );
+            done();
+        });
+        i18nextParser.end(fakeFile);
+    });
 
     it('creates two files per namespace and per locale', function (done) {
         var results = [];
@@ -229,7 +254,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/test_separators.json' ) {
+            if ( file.relative === 'en/test_separators.json' || file.relative === 'en\\test_separators.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -250,7 +275,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -273,7 +298,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -295,7 +320,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -389,7 +414,7 @@ describe('parser', function () {
         };
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/test_plural.json' ) {
+            if ( file.relative === 'en/test_plural.json' || file.relative === 'en\\test_plural.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -415,7 +440,7 @@ describe('parser', function () {
         };
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/test_context_plural.json' ) {
+            if ( file.relative === 'en/test_context_plural.json' || file.relative === 'en\\test_context_plural.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -435,7 +460,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -469,7 +494,7 @@ describe('parser', function () {
             contents: new Buffer("// FIX this doesn't work and this t is all alone\nt('first')\nt = function() {}")
         });
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -488,7 +513,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });
@@ -507,7 +532,7 @@ describe('parser', function () {
         });
 
         i18nextParser.on('data', function (file) {
-            if ( file.relative === 'en/translation.json' ) {
+            if ( file.relative === 'en/translation.json' || file.relative === 'en\\translation.json' ) {
                 result = JSON.parse( file.contents );
             }
         });

--- a/test/templating/translateHoc.js
+++ b/test/templating/translateHoc.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { translate } from 'react-i18next'
+
+class Test extends React.Component {
+  render () {
+    const { t } = this.props
+    return (
+      <div>
+        <h1>{t('hello_specific')}</h1>
+        <p>{t('common:hello_common')}</p>
+      </div>
+    )
+  }
+}
+
+export default translate('specific_namespace')(Test)


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
i18next-parser provide the ability to extract namespace from `t` function when provided with the key : `t('namespace:key')`
However, when using react-i18next and the high order component `translate`, the namespace is not provided with the `t` function but with the translate hoc.
```
class Component extends React.Component {
  ...
 // somewhere in jsx
  <p>{t('key')}</p>
}

// export component with translate
export default translate('namespace')(component)
```

**What is the chosen solution to this problem?**
This PR provide a new option `--react-namespace` which default to false. If set to true, i18n-parser will look for `translate` hig order component and use parsed namespace instead of `self.defaultNamespace`.