### PR TITLE
Add support for the $LOCALE and $FILENAME tags in the namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Thanks a lot to all the previous [contributors](https://github.com/i18next/i18ne
 - **--keep-removed**: Prevent keys no longer found from being removed
 - **--write-old false**: Avoid saving the \_old files
 - **--ignore-variables**: Don't fail when a variable is found
-- **--prefix <string>**: Prefix filename for each locale, eg.: 'pre-$LOCALE-' will yield 'pre-en-default.json'
-- **--suffix <string>**: Suffix filename for each locale, eg.: '-$suf-LOCALE' will yield 'default-suf-en.json'
-- **--extension <string>**: Specify extension for filename for each locale, eg.: '.$LOCALE.i18n' will yield 'default.en.i18n'
+- **--extension <string>**: Edit the extension of the files. Defaults to `.json`
+
+You can inject the locale tag in the namespace and extension using the `$LOCALE` variable, and you can inject the source file name in the namespace using the `$FILENAME` variable.
 
 ---
 
@@ -104,13 +104,11 @@ gulp.task('i18next', function() {
 - **locales**: An array of the locales in your applications. Defaults to `['en','fr']`
 - **parser**: A custom regex for the parser to use.
 - **writeOld**: Save the \_old files. Defaults to `true`
-- **prefix**: Add a custom prefix in front of the file name.
-- **suffix**: Add a custom suffix at the end of the file name.
 - **extension**: Edit the extension of the files. Defaults to `.json`
 - **keepRemoved**: Prevent keys no longer found from being removed
 - **ignoreVariables**: Don't fail when a variable is found
 
-You can inject the locale tag in either the prefix, suffix or extension using the `$LOCALE` variable.
+You can inject the locale tag in the namespace and extension using the `$LOCALE` variable, and you can inject the source file name in the namespace using the `$FILENAME` variable.
 
 ### Note on paths (why your translations are not saved)
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ const PLUGIN_NAME = 'i18next-parser';
 
 
 
+function deprecated(message) {
+	console.log('\x1b[33m%s%s\x1b[0m', 'i18next-parser: ', message);
+}
+
 function Parser(options, transformConfig) {
 
     var self = this;
@@ -32,13 +36,17 @@ function Parser(options, transformConfig) {
     this.contextSeparator   = options.contextSeparator || '_';
     this.translations       = [];
     this.extension          = options.extension || '.json';
-    this.suffix             = options.suffix || ''; // backward compatibility for 0.13
-    this.prefix             = options.prefix || ''; // backward compatibility for 0.13
     this.writeOld           = options.writeOld !== false;
     this.keepRemoved        = options.keepRemoved;
     this.ignoreVariables    = options.ignoreVariables || false;
     this.defaultValues      = options.defaultValues || false;
 
+    this.suffix             = options.suffix || ''; // backward compatibility for 0.13
+    this.prefix             = options.prefix || ''; // backward compatibility for 0.13
+	if (options.suffix || options.prefix) {
+		deprecated('The --prefix and --suffix options are deprecated. Please use the --namespace option instead.');
+	}
+	
     ['functions', 'locales'].forEach(function( attr ) {
         if ( (typeof self[ attr ] !== 'object') || ! self[ attr ].length ) {
             throw new PluginError(PLUGIN_NAME, '`'+attr+'` must be an array');
@@ -181,7 +189,7 @@ Parser.prototype._transform = function(file, encoding, done) {
             var namespace = self.defaultNamespace;
             if (file.path) {
                 var filename = path.basename(file.path, path.extname(file.path));
-                namespace = namespace.replace('$FILENAME', filename);
+                namespace = namespace.replace(/\$FILENAME/g, filename);
             }
             key = namespace + self.keySeparator + key;
         }
@@ -240,8 +248,8 @@ Parser.prototype._flush = function(done) {
             // get previous version of the files
             var filename = self.prefix + namespace + self.suffix;
             var extension = self.extension;
-            filename = filename.replace( '$LOCALE', locale );
-            extension = extension.replace( '$LOCALE', locale );
+            filename = filename.replace( /\$LOCALE/g, locale );
+            extension = extension.replace( /\$LOCALE/g, locale );
             var filenameOld = filename + '_old' + extension;
             filename += extension;
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -202,37 +202,6 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
-    it('handles prefix, suffix and extension with the current locale tag in each', function (done) {
-        var results = [];
-        var i18nextParser = Parser({
-            locales: ['en'],
-            namespace: 'default',
-            prefix: 'p-$LOCALE-',
-            suffix: '-s-$LOCALE',
-            extension: '.$LOCALE.i18n'
-        });
-        var fakeFile = new File({
-            contents: new Buffer("asd t('fourth')")
-        });
-
-        i18nextParser.on('data', function (file) {
-            results.push(file.relative);
-        });
-        i18nextParser.on('end', function () {
-            var expectedFiles = [
-                'en/p-en-default-s-en.en.i18n', 'en/p-en-default-s-en_old.en.i18n'
-            ];
-            var length = expectedFiles.length;
-
-            expectedFiles.forEach(function (filename) {
-                assert( results.indexOf( filename ) !== -1 );
-                if( ! --length ) done();
-            });
-        });
-
-        i18nextParser.end(fakeFile);
-    });
-
     it('handles custom namespace and key separators', function (done) {
         var result;
         var i18nextParser = Parser({
@@ -530,6 +499,35 @@ describe('parser', function () {
             assert.deepEqual( result, { first: '' });
             done();
         });
+        i18nextParser.end(fakeFile);
+    });
+    
+    it('handles custom namespace with the source file name and current locale tag', function (done) {
+        var results = [];
+        var i18nextParser = Parser({
+            locales: ['en'],
+            namespace: '$FILENAME_translation_$LOCALE',
+            extension: '.$LOCALE.i18n'
+        });
+        var fakeFile = new File({
+            contents: new Buffer("asd t('fourth')"), path: '/some/fake/path.html'
+        });
+
+        i18nextParser.on('data', function (file) {
+            results.push(file.relative);
+        });
+        i18nextParser.on('end', function () {
+            var expectedFiles = [
+                'en/path_translation_en.en.i18n', 'en/path_translation_en_old.en.i18n'
+            ];
+            var length = expectedFiles.length;
+
+            expectedFiles.forEach(function (filename) {
+                assert( results.indexOf( filename ) !== -1 );
+                if( ! --length ) done();
+            });
+        });
+
         i18nextParser.end(fakeFile);
     });
 });

--- a/test/parser.js
+++ b/test/parser.js
@@ -202,6 +202,37 @@ describe('parser', function () {
         i18nextParser.end(fakeFile);
     });
 
+    it('handles prefix, suffix and extension with the current locale tag in each', function (done) {
+        var results = [];
+        var i18nextParser = Parser({
+            locales: ['en'],
+            namespace: 'default',
+            prefix: 'p-$LOCALE-',
+            suffix: '-s-$LOCALE',
+            extension: '.$LOCALE.i18n'
+        });
+        var fakeFile = new File({
+            contents: new Buffer("asd t('fourth')")
+        });
+
+        i18nextParser.on('data', function (file) {
+            results.push(file.relative);
+        });
+        i18nextParser.on('end', function () {
+            var expectedFiles = [
+                'en/p-en-default-s-en.en.i18n', 'en/p-en-default-s-en_old.en.i18n'
+            ];
+            var length = expectedFiles.length;
+
+            expectedFiles.forEach(function (filename) {
+                assert( results.indexOf( filename ) !== -1 );
+                if( ! --length ) done();
+            });
+        });
+
+        i18nextParser.end(fakeFile);
+    });
+    
     it('handles custom namespace and key separators', function (done) {
         var result;
         var i18nextParser = Parser({
@@ -501,12 +532,12 @@ describe('parser', function () {
         });
         i18nextParser.end(fakeFile);
     });
-    
+	
     it('handles custom namespace with the source file name and current locale tag', function (done) {
         var results = [];
         var i18nextParser = Parser({
             locales: ['en'],
-            namespace: '$FILENAME_translation_$LOCALE',
+            namespace: 'pre-$FILENAME-$LOCALE $FILENAME_translation_$LOCALE suf-$FILENAME-$LOCALE',
             extension: '.$LOCALE.i18n'
         });
         var fakeFile = new File({
@@ -518,7 +549,7 @@ describe('parser', function () {
         });
         i18nextParser.on('end', function () {
             var expectedFiles = [
-                'en/path_translation_en.en.i18n', 'en/path_translation_en_old.en.i18n'
+                'en/pre-path-en path_translation_en suf-path-en.en.i18n', 'en/pre-path-en path_translation_en suf-path-en_old.en.i18n'
             ];
             var length = expectedFiles.length;
 


### PR DESCRIPTION
When a project is structured such that single files represent a namespace each, it is not desirable to include the namespace for each key in the source code. With this addition, it will be possible to inject the $FILENAME tag in the namespace such that each source file can have its own translation file.

With this addition, the --prefix and --suffix options are superfluous since they can be also added to the namespace. They are still supported for backward compatibility but not mentioned anymore in the documentation.