### PR TITLE
Allow indentation level to be specified as a cli parameter

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -35,6 +35,7 @@ program
   .option( '--write-old <string>'                , 'Save (or don\'t if false) _old files' )
   .option( '--ignore-variables'                  , 'Don\'t fail when a variable is found' )
   .option( '--default-values'                    , 'Extract default values' )
+  .option( '--indentation <number>'              , 'Specify size of indentation in output' )
   .parse( process.argv );
 
 
@@ -78,6 +79,7 @@ program.writeOld = program.writeOld !== 'false';
 program.directoryFilter = program.directoryFilter && program.directoryFilter.split(',');
 program.fileFilter = program.fileFilter && program.fileFilter.split(',');
 program.output = path.resolve(process.cwd(), output);
+program.indentation = program.indentation && parseInt(programm.indentation, 10);
 
 
 

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function Parser(options, transformConfig) {
     this.keepRemoved        = options.keepRemoved;
     this.ignoreVariables    = options.ignoreVariables || false;
     this.defaultValues      = options.defaultValues || false;
+    this.indentation        = options.indentation || 2;
 
     ['functions', 'locales'].forEach(function( attr ) {
         if ( (typeof self[ attr ] !== 'object') || ! self[ attr ].length ) {
@@ -289,7 +290,7 @@ Parser.prototype._flush = function(done) {
             mergedTranslationsFile = new File({
               path: namespacePath,
               base: base,
-              contents: new Buffer( JSON.stringify( mergedTranslations.new, null, 2 ) )
+              contents: new Buffer( JSON.stringify( mergedTranslations.new, null, this.indentation ) )
             });
             this.emit( 'writing', namespacePath );
             self.push( mergedTranslationsFile );
@@ -298,7 +299,7 @@ Parser.prototype._flush = function(done) {
                 mergedOldTranslationsFile = new File({
                     path: namespaceOldPath,
                     base: base,
-                    contents: new Buffer(JSON.stringify(mergedTranslations.old, null, 2))
+                    contents: new Buffer(JSON.stringify(mergedTranslations.old, null, this.indentation))
                 });
                 this.emit( 'writing', namespaceOldPath );
                 self.push( mergedOldTranslationsFile );


### PR DESCRIPTION
This PR allows to specify the indentation level of the final output content from a CLI parameter, as so:

`i18next /path/to/file/or/dir --indentation 4 -o /output/directory`