### PR TITLE
No longer depending on gulp-util as it is deprecated, closes #76

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-var gutil       = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var Transform   = require('stream').Transform;
 var util        = require('util');
 var helpers     = require('./src/helpers');

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     "url": "https://github.com/i18next/i18next-parser"
   },
   "dependencies": {
-    "lodash": "~4.17.3",
-    "readdirp": "~2.1.0",
-    "concat-stream": "~1.6.0",
-    "commander": "~2.9.0",
-    "mkdirp": "~0.5.1",
     "colors": "~1.1.2",
+    "commander": "~2.9.0",
+    "concat-stream": "~1.6.0",
+    "lodash": "~4.17.3",
+    "mkdirp": "~0.5.1",
+    "plugin-error": "^1.0.1",
+    "readdirp": "~2.1.0",
     "through2": "~2.0.3",
-    "vinyl": "~2.0.1",
-    "gulp-util": "~3.0.7"
+    "vinyl": "~2.0.1"
   },
   "engines": {
     "node": ">=0.10.22"


### PR DESCRIPTION
Now using the more specific package plugin-error.