### PR TITLE
Fix react test to have valid jsx

### DIFF
--- a/test/templating/react.jsx
+++ b/test/templating/react.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { translate } from 'react-i18next'
+import { translate, Trans, Interpolate } from 'react-i18next'
 
 class Test extends React.Component {
   render () {


### PR DESCRIPTION
`Trans` and `Interpolate` need to be imported to be used.

By the way, i18next-parser should not extract the whole html tags, but use <0>, <1> and so on as seen [here](https://react.i18next.com/components/trans-component.html).