### PR TITLE
Improved parsing of Trans component

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -105,9 +105,13 @@ function populateHash(source, target = {}) {
   return target
 }
 
+class ParsingError extends Error {
+
+}
 
 export {
   dotPathToHash,
   mergeHashes,
-  populateHash
+  populateHash,
+  ParsingError
 }

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -1,4 +1,7 @@
+import assert from 'assert'
 import HTMLLexer from './html-lexer'
+import BaseLexer from './base-lexer';
+import { ParsingError } from '../helpers';
 
 export default class JsxLexer extends HTMLLexer {
   constructor(options = {}) {
@@ -44,7 +47,7 @@ export default class JsxLexer extends HTMLLexer {
       const key = attrs.keys
 
       if (matches[3] && !attrs.options.defaultValue) {
-        attrs.options.defaultValue = matches[3].trim()
+        attrs.options.defaultValue = this.eraseTags(matches[3].trim()).replace(/\\s+/g, ' ')
       }
 
       if (key) {
@@ -53,5 +56,163 @@ export default class JsxLexer extends HTMLLexer {
     }
 
     return this.keys
+  }
+
+  /**
+   * Recursively convert html tags and js injections to tags with the child index in it
+   *
+   * @param {string} string
+   *
+   * @returns string
+   */
+  eraseTags(string) {
+    return this.parseJsx(string).map((child, index) => {
+      switch(child.type) {
+        case 'text': return child.content;
+        case 'js': return `<${index}>{${child.content}}</${index}>`;
+        case 'tag': return `<${index}>${this.eraseTags(child.content)}</${index}>`;
+        default: throw new ParsingError('Unknown parsed content: ' + child.type);
+      }
+    }).join('')
+  }
+
+  /**
+   * Convert jsx into an array of children
+   * @param {*} string
+   */
+  parseJsx(string) {
+    if (string.length === 0) {
+      return []
+    }
+    if (/^<[A-Z]/i.test(string)) {
+      const tag  = this.parseTag(string)
+      return [{...tag, type: 'tag'}, ...this.parseJsx(string.slice(tag.length))]
+    }
+    if (string[0] === '{') {
+      const js = this.parseJsInHtml(string)
+      return [{...js, type: 'js'}, ...this.parseJsx(string.slice(js.length))]
+    }
+    const nextJs = string.indexOf('{') === -1 ? Number.POSITIVE_INFINITY : string.indexOf('{')
+    const nextTag = /<[A-Z]/i.test(string) ? /<[A-Z]/i.exec(string).index : Number.POSITIVE_INFINITY
+    const textEnd = Math.min(nextJs, nextTag, string.length)
+
+    return [{content: string.slice(0, textEnd), length: textEnd, type: 'text'}, ...this.parseJsx(string.slice(textEnd))]
+  }
+
+  /**
+   *
+   * @param {string} string A string beginning with an HTML tag
+   * @returns {closingTag: boolean, tag: string, length: number, content: string}
+   */
+  parseTag(string) {
+    // this.eraseTags checks this first, so should be ok
+    assert(/^<[A-Z]/i.test(string), "The string must begin with an html tag")
+
+    const tag = /[A-Z-]+/i.exec(string)[0].toLowerCase()
+
+    let currentIndex = tag.length+1
+
+    while (currentIndex < string.length) {
+      // Check end of self-closing tag's opening tag
+      if (string[currentIndex] === ">") {
+        let openTag = string.slice(0, currentIndex+1)
+        let closeTagMatch = (new RegExp('</' + tag + '>', 'i')).exec(string.slice(openTag.length))
+
+        if (!closeTagMatch) {
+          throw new ParsingError("No matching closing tag for " + tag)
+        }
+        let closeTag = closeTagMatch[0]
+        let content = string.slice(openTag.length, closeTagMatch.index+openTag.length)
+
+        return {
+          tag,
+          content,
+          closingTag: false,
+          length: closeTagMatch.index + closeTag.length + openTag.length
+        }
+      }
+
+      // Check end of closing tag
+      if (string.slice(currentIndex, currentIndex+2) == "/>") {
+        return {
+          tag,
+          content: '',
+          closingTag: true,
+          length: currentIndex+2
+        }
+      }
+
+      const char = string[currentIndex]
+      if (char == "'" || char == '"' || char == '`') {
+        currentIndex += this.parseQuote(string.slice(currentIndex)).length
+        continue
+      }
+
+      if (char == '{') {
+        // This is a JS insertion in the JSX, with braces and parenthesis
+        currentIndex += this.parseJsInHtml(string.slice(currentIndex)).length
+        continue
+      }
+
+      currentIndex++
+    }
+
+    // Premature end
+    throw new ParsingError(`The html tag ${tag} is not closed`)
+  }
+
+  parseJsInHtml(string) {
+    assert(string.length > 0 && string[0] === '{', 'A js expression mixed in html must begin with {')
+
+    const stack = ['}']
+    let currentIndex = 1
+
+    while (currentIndex < string.length) {
+      switch (string[currentIndex]) {
+        case '{': stack.unshift('}'); break
+        case '(': stack.unshift(')'); break
+        case '"':
+        case "'":
+        case "`": currentIndex += this.parseQuote(string.slice(currentIndex)).length; continue
+        case '}':
+        case ')': {
+          if (stack[0] != string[currentIndex]) {
+            throw new ParsingError(`Expected ${stack[0]}, got ${string[currentIndex]}`)
+          }
+          stack.shift()
+
+          if (stack.length === 0) {
+            return {length: currentIndex + 1, content: string.slice(1, currentIndex)}
+          }
+        }
+        default: break
+      }
+
+      currentIndex++
+    }
+
+    throw new ParsingError('Unexpected end of js input')
+  }
+
+  parseQuote(string) {
+    assert(string.length > 0 && (string[0] === '"' || string[0] === "'" || string[0] === '`'), "The string must begin with a quote")
+    const char = string[0]
+
+    // This is a quote, we go to the end quote
+    const regex = new RegExp('^(?:' +
+    [
+      BaseLexer.singleQuotePattern,
+      BaseLexer.doubleQuotePattern,
+      BaseLexer.backQuotePattern
+    ].join('|') +
+    ')')
+
+    const quoteStringMatch = regex.exec(string)
+
+    if (!quoteStringMatch) {
+      throw new ParsingError(`No end quote, closing ${char} expected`)
+    }
+
+    return {length: quoteStringMatch[0].length, content: quoteStringMatch.slice(1, quoteStringMatch[0].length - 1)}
   }
 }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -183,7 +183,7 @@ describe('parser', () => {
       first: '',
       second: '',
       third: {
-        first: 'Hello <strong title={t(\'fourth\')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.'
+        first: 'Hello <1><0>{{name}}</0></1>, you have <3>{{count}}</3> unread message. <5>Go to messages</5>.'
       },
       fourth: '',
       fifth: '',
@@ -572,7 +572,7 @@ describe('parser', () => {
         first: '',
         second: '',
         third: {
-          first: 'Hello <strong title={t(\'fourth\')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.'
+          first: 'Hello <1><0>{{name}}</0></1>, you have <3>{{count}}</3> unread message. <5>Go to messages</5>.'
         },
         fourth: '',
         fifth: '',

--- a/test/templating/react.jsx
+++ b/test/templating/react.jsx
@@ -21,7 +21,7 @@ class Test extends React.Component {
         <h1>{t('first')}</h1>
         <Interpolate i18nKey="second" value="some thing" component={interpolateComponent} />
         <Trans i18nKey="third.first" count={count}>
-            Hello <strong title={t('fourth')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
+          Hello <strong title={t('fourth')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
         </Trans>
         <span><Trans i18nKey="fifth" count={count} /></span>
       </div>


### PR DESCRIPTION
Based on https://react.i18next.com/components/trans-component.html

Each html tag (closing or self-closing) and each js expression is converted to `<x>content</x>` where `x` is the index of tag/expression in the array of children of the current tag (`Trans` being the root tag).

The example:

```jsx
Hello <strong title={t('fourth')}>{{name}}</strong>, you have {{count}} unread message. <Link to="/msgs">Go to messages</Link>.
```
Becomes:

```jsx
Hello <1><0>{{name}}</0></1>, you have <3>{{count}}</3> unread message. <5>Go to messages</5>.
```

You may notice that I deviated from the usual way of parsing. I use regexps for parsing quotes, but for the rest I don't use regexps. This avoids some caveats with regexps, for example `<a stuff="a>" ....>` with regexps the first closing `>` would trigger the end of the tag even though it shouldn't as it's surrounded by quotes.

The js parser *could* be improved to try and detect keys of objects, for example `{{name: 'Albert'}}` is now parsed as is, but it should render  `{{name}}`. That said, it's good practice to set the variables before rendering the jsx, and as long as the user of the parser is aware, there should be no problems.