### PR TITLE
added support for keyless react-i18next Trans components

### DIFF
--- a/dist/lexers/jsx-lexer.js
+++ b/dist/lexers/jsx-lexer.js
@@ -32,20 +32,25 @@ JsxLexer = function (_HTMLLexer) {_inherits(JsxLexer, _HTMLLexer);
       }
 
       return this.keys;
-    } }, { key: 'extractTrans', value: function extractTrans(
+    }
 
+    /**
+      * Extract tags and content from the Trans component.
+      * @param {string} string
+      * @returns {array} Array of key options
+      */ }, { key: 'extractTrans', value: function extractTrans(
     content) {
       var matches = void 0;
-      var closingTagPattern = '(?:<Trans([^>]*\\s' + this.attr + '[^>]*?)\\/>)';
-      var selfClosingTagPattern = '(?:<Trans([^>]*\\s' + this.attr + '[^>]*?)>((?:\\s|.)*?)<\\/Trans>)';
+      var selfClosingTagPattern = '(?:<\\s*Trans([^>]*)?/>)';
+      var closingTagPattern = '(?:<\\s*Trans([^>]*)?>((?:(?!</\\s*Trans\\s*>)[^])*)</\\s*Trans\\s*>)';
       var regex = new RegExp(
-      [closingTagPattern, selfClosingTagPattern].join('|'),
+      [selfClosingTagPattern, closingTagPattern].join('|'),
       'gi');
 
 
       while (matches = regex.exec(content)) {
         var attrs = this.parseAttributes(matches[1] || matches[2]);
-        var key = attrs.keys;
+        var key = attrs.keys || matches[3];
 
         if (matches[3] && !attrs.options.defaultValue) {
           attrs.options.defaultValue = this.eraseTags(matches[0]).replace(/\s+/g, ' ');

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -34,18 +34,23 @@ export default class JsxLexer extends HTMLLexer {
     return this.keys
   }
 
+  /**
+  * Extract tags and content from the Trans component.
+  * @param {string} string
+  * @returns {array} Array of key options
+  */
   extractTrans(content) {
     let matches
-    const closingTagPattern = '(?:<Trans([^>]*\\s' + this.attr + '[^>]*?)\\/>)'
-    const selfClosingTagPattern = '(?:<Trans([^>]*\\s' + this.attr + '[^>]*?)>((?:\\s|.)*?)<\\/Trans>)'
+    const selfClosingTagPattern = '(?:<\\s*Trans([^>]*)?/>)'
+    const closingTagPattern = '(?:<\\s*Trans([^>]*)?>((?:(?!</\\s*Trans\\s*>)[^])*)</\\s*Trans\\s*>)'
     const regex = new RegExp(
-      [closingTagPattern, selfClosingTagPattern].join('|'),
+      [selfClosingTagPattern, closingTagPattern].join('|'),
       'gi'
     )
 
     while (matches = regex.exec(content)) {
       const attrs = this.parseAttributes(matches[1] || matches[2])
-      const key = attrs.keys
+      const key = attrs.keys || matches[3]
 
       if (matches[3] && !attrs.options.defaultValue) {
         attrs.options.defaultValue = this.eraseTags(matches[0]).replace(/\s+/g, ' ')

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -31,6 +31,27 @@ describe('JsxLexer', () => {
       ])
       done()
     })
+
+    it('extracts keys from Trans elements without an i18nKey', (done) => {
+      const Lexer = new JsxLexer()
+      const content = '<Trans count={count}>Yo</Trans>'
+      assert.deepEqual(Lexer.extractTrans(content), [
+        { key: 'Yo', defaultValue: 'Yo' }
+      ])
+      done()
+    })
+
+    it('doesn\'t add a blank key for self-closing or empty tags', (done) => {
+      const Lexer = new JsxLexer()
+      
+      const emptyTag = '<Trans count={count}></Trans>'
+      assert.deepEqual(Lexer.extractTrans(emptyTag), [])
+
+      const selfClosing = '<Trans count={count}/>'
+      assert.deepEqual(Lexer.extractTrans(selfClosing), [])
+
+      done()
+    })
   })
 
   describe('eraseTags()', () => {


### PR DESCRIPTION
react-i18next <Trans> components have support for using the content as the key. This adds support for that.

Note that we probably should move away from regex and towards an actual parser of some kind in the future... this (and the previous regex) will break if someone has an attribute on their Trans component with a '>' in it.