### PR TITLE
moved JSX parsing to acorn-jsx (is now a side-effect of JS parsing)

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -1,120 +1,69 @@
-import * as acorn from 'acorn-jsx'
+import * as walk from 'acorn/dist/walk'
 import assert from 'assert'
-import HTMLLexer from './html-lexer'
-import BaseLexer from './base-lexer'
 import { ParsingError } from '../helpers'
 
-export default class JsxLexer extends HTMLLexer {
-  constructor(options = {}) {
-    options.attr = options.attr || 'i18nKey'
-    super(options)
+export const JSXParserExtension = Object.assign({}, walk.base, {
+  JSXText(node, st, c) {
+    // We need this catch, but we don't need the catch to do anything.
+  },
+  JSXElement(node, st, c) {
+      node.openingElement.attributes.forEach((attr) => {
+          c(attr, st, attr.type);
+      });
+      node.children.forEach((child) => {
+          c(child, st, child.type);
+      });
+  },
+  JSXExpressionContainer(node, st, c) {
+      c(node.expression, st, node.expression.type);
+  },
+  JSXAttribute(node, st, c) {
+      if (node.value !== null) {
+          c(node.value, st, node.value.type);
+      }
+  },
+  JSXSpreadAttribute(node, st, c) {
+      c(node.argument, st, node.argument.type);
   }
+});
 
-  extract(content) {
-    this.extractInterpolate(content)
-    this.extractTrans(content)
-    return this.keys
-  }
+export function nodeToString(ast, string) {
+  const children = parseAcornPayload(ast.children, string)
 
-  extractInterpolate(content) {
-    let matches
-    const regex = new RegExp(
-      '<Interpolate([^>]*\\s' + this.attr + '[^>]*)\\/?>',
-      'gi'
-    )
+  const elemsToString = children => children.map((child, index) => {
+    switch(child.type) {
+      case 'text': return child.content
+      case 'js': return `<${index}>${child.content}</${index}>`
+      case 'tag': return `<${index}>${elemsToString(child.children)}</${index}>`
+      default: throw new ParsingError('Unknown parsed content: ' + child.type)
+    }
+  }).join('')
 
-    while (matches = regex.exec(content)) {
-      const attrs = this.parseAttributes(matches[1])
-      const key = attrs.keys
-      if (key) {
-        this.keys.push({ ...attrs.options, key })
+  return elemsToString(children)
+}
+
+function parseAcornPayload(children, originalString) {
+  return children.map(child => {
+    if (child.type === 'JSXText') {
+      return {
+        type: 'text',
+        content: child.value.replace(/^(?:\s*(\n|\r)\s*)?(.*)(?:\s*(\n|\r)\s*)?$/, '$2')
       }
     }
-
-    return this.keys
-  }
-
-  /**
-  * Extract tags and content from the Trans component.
-  * @param {string} string
-  * @returns {array} Array of key options
-  */
-  extractTrans(content) {
-    let matches
-    const selfClosingTagPattern = '(?:<\\s*Trans([^>]*)?/>)'
-    const closingTagPattern = '(?:<\\s*Trans([^>]*)?>((?:(?!</\\s*Trans\\s*>)[^])*)</\\s*Trans\\s*>)'
-    const regex = new RegExp(
-      [selfClosingTagPattern, closingTagPattern].join('|'),
-      'gi'
-    )
-
-    while (matches = regex.exec(content)) {
-      const attrs = this.parseAttributes(matches[1] || matches[2])
-      const key = attrs.keys || matches[3]
-
-      if (matches[3] && !attrs.options.defaultValue) {
-        attrs.options.defaultValue = this.eraseTags(matches[0]).replace(/\s+/g, ' ')
-      }
-
-      if (key) {
-        this.keys.push({ ...attrs.options, key })
+    else if (child.type === 'JSXElement') {
+      return {
+        type: 'tag',
+        children: parseAcornPayload(child.children, originalString)
       }
     }
-
-    return this.keys
-  }
-
-  /**
-   * Recursively convert html tags and js injections to tags with the child index in it
-   * @param {string} string
-   *
-   * @returns string
-   */
-  eraseTags(string) {
-    const acornAst = acorn.parse(string, {plugins: {jsx: true}})
-    const acornTransAst = acornAst.body[0].expression
-    const children = this.parseAcornPayload(acornTransAst.children, string)
-
-    const elemsToString = children => children.map((child, index) => {
-      switch(child.type) {
-        case 'text': return child.content
-        case 'js': return `<${index}>${child.content}</${index}>`
-        case 'tag': return `<${index}>${elemsToString(child.children)}</${index}>`
-        default: throw new ParsingError('Unknown parsed content: ' + child.type)
+    else if (child.type === 'JSXExpressionContainer') {
+      return {
+        type: 'js',
+        content: originalString.slice(child.start, child.end)
       }
-    }).join('')
-
-    return elemsToString(children)
-  }
-
-  /**
-   * Simplify the bulky AST given by Acorn
-   * @param {*} children An array of elements contained inside an html tag
-   * @param {string} originalString The original string being parsed
-   */
-  parseAcornPayload(children, originalString) {
-    return children.map(child => {
-      if (child.type === 'JSXText') {
-        return {
-          type: 'text',
-          content: child.value.replace(/^(?:\s*(\n|\r)\s*)?(.*)(?:\s*(\n|\r)\s*)?$/, '$2')
-        }
-      }
-      else if (child.type === 'JSXElement') {
-        return {
-          type: 'tag',
-          children: this.parseAcornPayload(child.children, originalString)
-        }
-      }
-      else if (child.type === 'JSXExpressionContainer') {
-        return {
-          type: 'js',
-          content: originalString.slice(child.start, child.end)
-        }
-      }
-      else {
-        throw new ParsingError('Unknown ast element when parsing jsx: ' + child.type)
-      }
-    }).filter(child => child.type !== 'text' || child.content)
-  }
+    }
+    else {
+      throw new ParsingError('Unknown ast element when parsing jsx: ' + child.type)
+    }
+  }).filter(child => child.type !== 'text' || child.content)
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -13,7 +13,7 @@ const lexers = {
   html: ['HTMLLexer'],
 
   js: ['JavascriptLexer'],
-  jsx: ['JsxLexer'],
+  jsx: ['JavascriptLexer'],
   mjs: ['JavascriptLexer'],
 
   default: ['JavascriptLexer']
@@ -30,10 +30,6 @@ export default class Parser extends EventEmitter {
   constructor(options = {}) {
     super(options)
     this.options = options
-
-    if (options.reactNamespace) {
-      lexers.js = lexers.jsx
-    }
 
     this.lexers = { ...lexers, ...options.lexers }
   }

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -1,12 +1,12 @@
 import { assert } from 'chai'
-import JsxLexer from '../../src/lexers/jsx-lexer'
+import JavascriptLexer from '../../src/lexers/javascript-lexer'
 
 describe('JsxLexer', () => {
   describe('extractInterpolate', () => {
     it('extracts keys from i18nKey attributes', (done) => {
-      const Lexer = new JsxLexer()
+      const Lexer = new JavascriptLexer()
       const content = '<Interpolate i18nKey="first" />'
-      assert.deepEqual(Lexer.extractInterpolate(content), [
+      assert.deepEqual(Lexer.extract(content), [
         { key: 'first' }
       ])
       done()
@@ -15,40 +15,58 @@ describe('JsxLexer', () => {
 
   describe('Trans', () => {
     it('extracts keys from i18nKey attributes from closing tags', (done) => {
-      const Lexer = new JsxLexer()
+      const Lexer = new JavascriptLexer()
       const content = '<Trans i18nKey="first" count={count}>Yo</Trans>'
-      assert.deepEqual(Lexer.extractTrans(content), [
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'first', defaultValue: 'Yo' }
+      ])
+      done()
+    })
+    
+    it('extracts keys from user-defined key attributes from closing tags', (done) => {
+      const Lexer = new JavascriptLexer({ attr: "myIntlKey" })
+      const content = '<Trans myIntlKey="first" count={count}>Yo</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
         { key: 'first', defaultValue: 'Yo' }
       ])
       done()
     })
 
     it('extracts keys from i18nKey attributes from self-closing tags', (done) => {
-      const Lexer = new JsxLexer()
+      const Lexer = new JavascriptLexer()
       const content = '<Trans i18nKey="first" count={count} />'
-      assert.deepEqual(Lexer.extractTrans(content), [
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'first' }
+      ])
+      done()
+    })
+
+    it('extracts keys from user-defined key attributes from self-closing tags', (done) => {
+      const Lexer = new JavascriptLexer({ attr: "myIntlKey" })
+      const content = '<Trans myIntlKey="first" count={count} />'
+      assert.deepEqual(Lexer.extract(content), [
         { key: 'first' }
       ])
       done()
     })
 
     it('extracts keys from Trans elements without an i18nKey', (done) => {
-      const Lexer = new JsxLexer()
+      const Lexer = new JavascriptLexer()
       const content = '<Trans count={count}>Yo</Trans>'
-      assert.deepEqual(Lexer.extractTrans(content), [
+      assert.deepEqual(Lexer.extract(content), [
         { key: 'Yo', defaultValue: 'Yo' }
       ])
       done()
     })
 
     it('doesn\'t add a blank key for self-closing or empty tags', (done) => {
-      const Lexer = new JsxLexer()
+      const Lexer = new JavascriptLexer()
       
       const emptyTag = '<Trans count={count}></Trans>'
-      assert.deepEqual(Lexer.extractTrans(emptyTag), [])
+      assert.deepEqual(Lexer.extract(emptyTag), [])
 
       const selfClosing = '<Trans count={count}/>'
-      assert.deepEqual(Lexer.extractTrans(selfClosing), [])
+      assert.deepEqual(Lexer.extract(selfClosing), [])
 
       done()
     })
@@ -56,9 +74,9 @@ describe('JsxLexer', () => {
 
   describe('eraseTags()', () => {
     it('erases tags from content', (done) => {
-      const Lexer = new JsxLexer()
+      const Lexer = new JavascriptLexer()
       const content = '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>'
-      assert.equal(Lexer.eraseTags(content), 'a<1>c<1>z</1></1><2>{d}</2><3></3>')
+      assert.equal(Lexer.extract(content)[0].defaultValue, 'a<1>c<1>z</1></1><2>{d}</2><3></3>')
       done()
     })
   })


### PR DESCRIPTION
Major notes:

1. JSX parsing now happens as a side effect of a JSX node existing in any JS file. 
    - The only major **pro** here is that jsx code inside a .js file gets parsed correctly instead of silently failing -- we also no longer need to ask the user to define a config param to pull from JSX. If the file is only js, the JSX paths never get hit.
    - Conversely, the only major **con** here is that the js lexer is a bit more complex. I kept as much as was easy out of the js lexer, but more could be moved. For example: the traps object could be dynamically generated -- if it was, we could move the JSXElement trap into the jsx-lexer file.
2. Changed the JS trap from `Expression` to `CallExpression` -- the JS was checking for it anyways in the body of the trap and CallExpression catches js nested in JSX. Was there a reason to favor `Expression` over `CallExpression`
3. Added a couple tests for user-defined key attributes.

(comments incoming)