### PR TITLE
a few minor fixes and tweaks (including a fix for #95)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -68,7 +68,8 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
         var key = entry.key;
         var parts = key.split(_this2.options.namespaceSeparator);
 
-        if (parts.length > 1) {
+        // make sure we're not pulling a 'namespace' out of a default value
+        if (parts.length > 1 && key !== entry.defaultValue) {
           entry.namespace = parts.shift();
         } else
         if (extension === 'jsx' || _this2.options.reactNamespace) {

--- a/dist/lexers/base-lexer.js
+++ b/dist/lexers/base-lexer.js
@@ -14,7 +14,7 @@ BaseLexer = function (_EventEmitter) {_inherits(BaseLexer, _EventEmitter);
       var isDefaultValueString = this.validateString(secondArgument);
 
       if (!isKeyString) {
-        this.emit('warning', 'Key is not a string litteral: ' + firstArgument);
+        this.emit('warning', 'Key is not a string literal: ' + firstArgument);
       } else
       {
         var result = _extends({},

--- a/dist/lexers/javascript-lexer.js
+++ b/dist/lexers/javascript-lexer.js
@@ -43,14 +43,14 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
         if (keyArgument && keyArgument.type === 'BinaryExpression') {
           var concatenatedString = this.concatenateString(keyArgument);
           if (!concatenatedString) {
-            this.emit('warning', 'Key is not a string litteral: ' + keyArgument.name);
+            this.emit('warning', 'Key is not a string literal: ' + keyArgument.name);
             return;
           }
           entry.key = concatenatedString;
         } else
         {
           if (keyArgument.type === 'Identifier') {
-            this.emit('warning', 'Key is not a string litteral: ' + keyArgument.name);
+            this.emit('warning', 'Key is not a string literal: ' + keyArgument.name);
           }
 
           return;

--- a/dist/lexers/jsx-lexer.js
+++ b/dist/lexers/jsx-lexer.js
@@ -115,9 +115,35 @@ JsxLexer = function (_JavascriptLexer) {_inherits(JsxLexer, _JavascriptLexer);
 
         } else
         if (child.type === 'JSXExpressionContainer') {
+          // strip empty expressions
+          if (child.expression.type === 'JSXEmptyExpression')
+          return {
+            type: 'text',
+            content: ''
+
+
+            // strip properties from ObjectExpressions
+            // annoying (and who knows how many other exceptions we'll need to write) but necessary
+          };else if (child.expression.type === 'ObjectExpression') {
+            var content = '{';
+            var start = child.expression.start;
+
+            child.expression.properties.forEach(function (prop) {
+              content += originalString.slice(start, prop.key.end);
+              start = prop.value.end;
+            });
+            content += originalString.slice(start, child.expression.end) + '}';
+
+            return {
+              type: 'js',
+              content: content };
+
+          }
+
+          // slice on the expression so that we ignore comments around it
           return {
             type: 'js',
-            content: originalString.slice(child.start, child.end) };
+            content: '{' + originalString.slice(child.expression.start, child.expression.end) + '}' };
 
         } else
         {

--- a/dist/lexers/jsx-lexer.js
+++ b/dist/lexers/jsx-lexer.js
@@ -6,6 +6,9 @@ var JSXParserExtension = Object.assign({}, walk.base, {
   JSXText: function JSXText(node, st, c) {
     // We need this catch, but we don't need the catch to do anything.
   },
+  JSXEmptyExpression: function JSXEmptyExpression(node, st, c) {
+    // We need this catch, but we don't need the catch to do anything.
+  },
   JSXElement: function JSXElement(node, st, c) {
     node.openingElement.attributes.forEach(function (attr) {return c(attr, st, attr.type);});
     node.children.forEach(function (child) {return c(child, st, child.type);});

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,8 @@ export default class i18nTransform extends Transform {
       let key = entry.key
       const parts = key.split(this.options.namespaceSeparator)
 
-      if (parts.length > 1) {
+      // make sure we're not pulling a 'namespace' out of a default value
+      if (parts.length > 1 && key !== entry.defaultValue) {
         entry.namespace = parts.shift()
       }
       else if (extension === 'jsx' || this.options.reactNamespace) {

--- a/src/lexers/base-lexer.js
+++ b/src/lexers/base-lexer.js
@@ -14,7 +14,7 @@ export default class BaseLexer extends EventEmitter {
     const isDefaultValueString = this.validateString(secondArgument)
 
     if (!isKeyString) {
-      this.emit('warning', `Key is not a string litteral: ${firstArgument}`)
+      this.emit('warning', `Key is not a string literal: ${firstArgument}`)
     }
     else {
       const result = {

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -43,14 +43,14 @@ export default class JavascriptLexer extends BaseLexer {
       else if (keyArgument && keyArgument.type === 'BinaryExpression') {
         const concatenatedString = this.concatenateString(keyArgument)
         if (!concatenatedString) {
-          this.emit('warning', `Key is not a string litteral: ${keyArgument.name}`)
+          this.emit('warning', `Key is not a string literal: ${keyArgument.name}`)
           return
         }
         entry.key = concatenatedString
       }
       else {
         if (keyArgument.type === 'Identifier') {
-          this.emit('warning', `Key is not a string litteral: ${keyArgument.name}`)
+          this.emit('warning', `Key is not a string literal: ${keyArgument.name}`)
         }
 
         return

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -6,6 +6,9 @@ const JSXParserExtension = Object.assign({}, walk.base, {
   JSXText(node, st, c) {
     // We need this catch, but we don't need the catch to do anything.
   },
+  JSXEmptyExpression(node, st, c) {
+    // We need this catch, but we don't need the catch to do anything.
+  },
   JSXElement(node, st, c) {
     node.openingElement.attributes.forEach(attr => c(attr, st, attr.type))
     node.children.forEach(child => c(child, st, child.type))

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -59,6 +59,15 @@ describe('JsxLexer', () => {
       done()
     })
 
+    it('extracts keys from Trans elements and ignores values of expressions', (done) => {
+      const Lexer = new JsxLexer()
+      const content = '<Trans count={count}>{{key: property}}</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: '<0>{{key}}</0>', defaultValue: '<0>{{key}}</0>' }
+      ])
+      done()
+    })
+
     it('doesn\'t add a blank key for self-closing or empty tags', (done) => {
       const Lexer = new JsxLexer()
 
@@ -75,6 +84,13 @@ describe('JsxLexer', () => {
       const Lexer = new JsxLexer()
       const content = '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>'
       assert.equal(Lexer.extract(content)[0].defaultValue, 'a<1>c<1>z</1></1><2>{d}</2><3></3>')
+      done()
+    })
+
+    it('erases comment expressions', (done) => {
+      const Lexer = new JsxLexer()
+      const content = '<Trans>{/* some comment */}Some Content</Trans>'
+      assert.equal(Lexer.extract(content)[0].defaultValue, 'Some Content')
       done()
     })
   })

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -190,7 +190,9 @@ describe('parser', () => {
       fourth: '',
       fifth: '',
       bar: '',
-      foo: ''
+      foo: '',
+      "This should be part of the value and the key": "This should be part of the value and the key",
+      "don't split <1>{{ on }}</1>": "don't split <1>{{ on }}</1>"
     }
 
     i18nextParser.on('data', file => {
@@ -581,7 +583,9 @@ describe('parser', () => {
         fourth: '',
         fifth: '',
         bar: '',
-        foo: ''
+        foo: '',
+        "This should be part of the value and the key": "This should be part of the value and the key",
+        "don't split <1>{{ on }}</1>": "don't split <1>{{ on }}</1>"
       }
 
       i18nextParser.on('data', file => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -820,7 +820,7 @@ describe('parser', () => {
       })
 
       i18nextParser.on('warning', message => {
-        assert.equal(message, 'Key is not a string litteral: variable')
+        assert.equal(message, 'Key is not a string literal: variable')
         done()
       })
       i18nextParser.end(fakeFile)

--- a/test/templating/react.jsx
+++ b/test/templating/react.jsx
@@ -30,6 +30,13 @@ class Test extends React.Component {
          this should be trimmed.
          <i> and this shoudln't</i>
         </Trans>
+        <Trans>
+          This should be part of the value and the key
+          {/* this shouldn't */}
+        </Trans>
+        <Trans>
+          don't split {{ on: this }}
+        </Trans>
       </div>
     )
   }


### PR DESCRIPTION
1. Regarding splitting keys on namespaces. It doesn't make sense to split a key if the key was pulled from the content -- a complex sentence (or sentences) would make for a bizarre key (related to #95).

2. When we find `{{ foo: bar }}` replace it with `{{ foo }}` to match the behaviour of i18next-react.

3. Strip comments from expressions (i.e. {/* this gets removed */}) to match behaviour of i18next-react.

4. Typo.