### PR TITLE
fixed extra spacing in output; added tests for multiple keys in interpolation

### DIFF
--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -59,11 +59,20 @@ describe('JsxLexer', () => {
       done()
     })
 
-    it('extracts keys from Trans elements and ignores values of expressions', (done) => {
+    it('extracts keys from Trans elements and ignores values of expressions and spaces', (done) => {
       const Lexer = new JsxLexer()
-      const content = '<Trans count={count}>{{key: property}}</Trans>'
+      const content = '<Trans count={count}>{{ key: property }}</Trans>'
       assert.deepEqual(Lexer.extract(content), [
         { key: '<0>{{key}}</0>', defaultValue: '<0>{{key}}</0>' }
+      ])
+      done()
+    })
+
+    it('invalid interpolation gets stripped', (done) => {
+      const Lexer = new JsxLexer()
+      const content = '<Trans count={count}>before{{ key1, key2 }}after</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'beforeafter', defaultValue: 'beforeafter' }
       ])
       done()
     })

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -192,7 +192,7 @@ describe('parser', () => {
       bar: '',
       foo: '',
       "This should be part of the value and the key": "This should be part of the value and the key",
-      "don't split <1>{{ on }}</1>": "don't split <1>{{ on }}</1>"
+      "don't split <1>{{on}}</1>": "don't split <1>{{on}}</1>"
     }
 
     i18nextParser.on('data', file => {
@@ -585,7 +585,7 @@ describe('parser', () => {
         bar: '',
         foo: '',
         "This should be part of the value and the key": "This should be part of the value and the key",
-        "don't split <1>{{ on }}</1>": "don't split <1>{{ on }}</1>"
+        "don't split <1>{{on}}</1>": "don't split <1>{{on}}</1>"
       }
 
       i18nextParser.on('data', file => {
@@ -825,6 +825,20 @@ describe('parser', () => {
 
       i18nextParser.on('warning', message => {
         assert.equal(message, 'Key is not a string literal: variable')
+        done()
+      })
+      i18nextParser.end(fakeFile)
+    })
+
+    it('emits a `warning` event if a react value contains two variables', (done) => {
+      const i18nextParser = new i18nTransform({ output: 'test/locales' })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from('<Trans>{{ key1, key2 }}</Trans>'),
+        path: 'file.js'
+      })
+
+      i18nextParser.on('warning', message => {
+        assert.equal(message, 'The passed in object contained more than one variable - the object should look like {{ value, format }} where format is optional.')
         done()
       })
       i18nextParser.end(fakeFile)


### PR DESCRIPTION
i18next-react has some interesting behaviour. I suspect we'll be tweaking this for a while. 😕

Notes for this time:
1. `<Trans>before {{ key1, key2 }} after</Trans>` produces a warn, and a default key of `before  after`.
2. Whitespace and values are ignored. These all produce a default key of `<1>{{key1}}</1>`.
    ```jsx
    <Trans>{{ key1: 'value' }}</Trans>
    <Trans>{{key1: 'other value'}}</Trans>
    <Trans>{{key1}}</Trans>
    <Trans>{{ key1 }}</Trans>
    ``` 
3. If included, a `format` property is ignored for the production of the key. (i.e. `<Trans>{{ key1 }}</Trans>` and `<Trans>{{ key1, format }}</Trans>` both produce a key of `<1>{{key1}}</1>`.

Follow their pattern, this will now produce a warn in the first case also.