### PR TITLE
Correct lineEnding option

### DIFF
--- a/dist/transform.js
+++ b/dist/transform.js
@@ -199,10 +199,10 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
       if (this.options.lineEnding === 'auto') {
         text = _eol2.default.auto(text);
       } else
-      if (lineEnding === '\r\n' || lineEnding === 'crlf') {
+      if (this.options.lineEnding === '\r\n' || this.options.lineEnding === 'crlf') {
         text = _eol2.default.crlf(text);
       } else
-      if (lineEnding === '\r' || lineEnding === 'cr') {
+      if (this.options.lineEnding === '\r' || this.options.lineEnding === 'cr') {
         text = _eol2.default.cr(text);
       } else
       {

--- a/src/transform.js
+++ b/src/transform.js
@@ -199,10 +199,10 @@ export default class i18nTransform extends Transform {
     if (this.options.lineEnding === 'auto') {
       text = eol.auto(text)
     }
-    else if (lineEnding === '\r\n' || lineEnding === 'crlf') {
+    else if (this.options.lineEnding === '\r\n' || this.options.lineEnding === 'crlf') {
       text = eol.crlf(text)
     }
-    else if (lineEnding === '\r' || lineEnding === 'cr') {
+    else if (this.options.lineEnding === '\r' || this.options.lineEnding === 'cr') {
       text = eol.cr(text)
     }
     else {


### PR DESCRIPTION
While trying to use the _lineEnding_ option, I've got the following error message
```
      if (lineEnding === '\r\n' || lineEnding === 'crlf') {
      ^
ReferenceError: lineEnding is not defined
```

I've just corrected this piece of code to allow using the _lineEnding_ option..