### PR TITLE
Adding support for additional acorn plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,8 @@ Note the presence of a `default` which will catch any extension that is not list
         lexer: 'JavascriptLexer',
         acorn: {
           plugins: {
-            stage3: true,
             jsx: true,
             objectRestSpread: true,
-            staticClassPropertyInitializer: true,
             es7: true
           }
         }

--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ Note the presence of a `default` which will catch any extension that is not list
         functions: ['translate', '__']
       }
     ],
+    js: [
+      {
+        lexer: 'JavascriptLexer',
+        acorn: {
+          plugins: {
+            stage3: true,
+            jsx: true,
+            objectRestSpread: true,
+            staticClassPropertyInitializer: true,
+            es7: true
+          }
+        }
+      }
+    ]
     // ...
   }
 }

--- a/dist/lexers/javascript-lexer.js
+++ b/dist/lexers/javascript-lexer.js
@@ -1,8 +1,6 @@
 "use strict";Object.defineProperty(exports, "__esModule", { value: true });var _extends = Object.assign || function (target) {for (var i = 1; i < arguments.length; i++) {var source = arguments[i];for (var key in source) {if (Object.prototype.hasOwnProperty.call(source, key)) {target[key] = source[key];}}}return target;};var _createClass = function () {function defineProperties(target, props) {for (var i = 0; i < props.length; i++) {var descriptor = props[i];descriptor.enumerable = descriptor.enumerable || false;descriptor.configurable = true;if ("value" in descriptor) descriptor.writable = true;Object.defineProperty(target, descriptor.key, descriptor);}}return function (Constructor, protoProps, staticProps) {if (protoProps) defineProperties(Constructor.prototype, protoProps);if (staticProps) defineProperties(Constructor, staticProps);return Constructor;};}();var _acornJsx = require("acorn-jsx");var acorn = _interopRequireWildcard(_acornJsx);
-var _inject = require("acorn-stage3/inject");var _inject2 = _interopRequireDefault(_inject);
-var _inject3 = require("acorn-object-rest-spread/inject");var _inject4 = _interopRequireDefault(_inject3);
+var _inject = require("acorn-object-rest-spread/inject");var _inject2 = _interopRequireDefault(_inject);
 var _acornEs = require("acorn-es7");var _acornEs2 = _interopRequireDefault(_acornEs);
-var _inject5 = require("acorn-static-class-property-initializer/inject");var _inject6 = _interopRequireDefault(_inject5);
 var _walk = require("acorn/dist/walk");var walk = _interopRequireWildcard(_walk);
 var _baseLexer = require("./base-lexer");var _baseLexer2 = _interopRequireDefault(_baseLexer);function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}function _interopRequireWildcard(obj) {if (obj && obj.__esModule) {return obj;} else {var newObj = {};if (obj != null) {for (var key in obj) {if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key];}}newObj.default = obj;return newObj;}}function _classCallCheck(instance, Constructor) {if (!(instance instanceof Constructor)) {throw new TypeError("Cannot call a class as a function");}}function _possibleConstructorReturn(self, call) {if (!self) {throw new ReferenceError("this hasn't been initialised - super() hasn't been called");}return call && (typeof call === "object" || typeof call === "function") ? call : self;}function _inherits(subClass, superClass) {if (typeof superClass !== "function" && superClass !== null) {throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);}subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } });if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;}var
 
@@ -21,17 +19,11 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
       var localAcorn = acorn;
 
       if (this.acornOptions.plugins) {
-        if (this.acornOptions.plugins.stage3) {
-          localAcorn = (0, _inject2.default)(localAcorn);
-        }
         if (this.acornOptions.plugins.es7) {
           (0, _acornEs2.default)(localAcorn);
         }
-        if (this.acornOptions.plugins.staticClassPropertyInitializer) {
-          (0, _inject6.default)(localAcorn);
-        }
         if (this.acornOptions.plugins.objectRestSpread) {
-          (0, _inject4.default)(localAcorn);
+          (0, _inject2.default)(localAcorn);
         }
       }
 

--- a/dist/lexers/javascript-lexer.js
+++ b/dist/lexers/javascript-lexer.js
@@ -1,6 +1,10 @@
-'use strict';Object.defineProperty(exports, "__esModule", { value: true });var _extends = Object.assign || function (target) {for (var i = 1; i < arguments.length; i++) {var source = arguments[i];for (var key in source) {if (Object.prototype.hasOwnProperty.call(source, key)) {target[key] = source[key];}}}return target;};var _createClass = function () {function defineProperties(target, props) {for (var i = 0; i < props.length; i++) {var descriptor = props[i];descriptor.enumerable = descriptor.enumerable || false;descriptor.configurable = true;if ("value" in descriptor) descriptor.writable = true;Object.defineProperty(target, descriptor.key, descriptor);}}return function (Constructor, protoProps, staticProps) {if (protoProps) defineProperties(Constructor.prototype, protoProps);if (staticProps) defineProperties(Constructor, staticProps);return Constructor;};}();var _acornJsx = require('acorn-jsx');var acorn = _interopRequireWildcard(_acornJsx);
-var _walk = require('acorn/dist/walk');var walk = _interopRequireWildcard(_walk);
-var _baseLexer = require('./base-lexer');var _baseLexer2 = _interopRequireDefault(_baseLexer);function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}function _interopRequireWildcard(obj) {if (obj && obj.__esModule) {return obj;} else {var newObj = {};if (obj != null) {for (var key in obj) {if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key];}}newObj.default = obj;return newObj;}}function _classCallCheck(instance, Constructor) {if (!(instance instanceof Constructor)) {throw new TypeError("Cannot call a class as a function");}}function _possibleConstructorReturn(self, call) {if (!self) {throw new ReferenceError("this hasn't been initialised - super() hasn't been called");}return call && (typeof call === "object" || typeof call === "function") ? call : self;}function _inherits(subClass, superClass) {if (typeof superClass !== "function" && superClass !== null) {throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);}subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } });if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;}var
+"use strict";Object.defineProperty(exports, "__esModule", { value: true });var _extends = Object.assign || function (target) {for (var i = 1; i < arguments.length; i++) {var source = arguments[i];for (var key in source) {if (Object.prototype.hasOwnProperty.call(source, key)) {target[key] = source[key];}}}return target;};var _createClass = function () {function defineProperties(target, props) {for (var i = 0; i < props.length; i++) {var descriptor = props[i];descriptor.enumerable = descriptor.enumerable || false;descriptor.configurable = true;if ("value" in descriptor) descriptor.writable = true;Object.defineProperty(target, descriptor.key, descriptor);}}return function (Constructor, protoProps, staticProps) {if (protoProps) defineProperties(Constructor.prototype, protoProps);if (staticProps) defineProperties(Constructor, staticProps);return Constructor;};}();var _acornJsx = require("acorn-jsx");var acorn = _interopRequireWildcard(_acornJsx);
+var _inject = require("acorn-stage3/inject");var _inject2 = _interopRequireDefault(_inject);
+var _inject3 = require("acorn-object-rest-spread/inject");var _inject4 = _interopRequireDefault(_inject3);
+var _acornEs = require("acorn-es7");var _acornEs2 = _interopRequireDefault(_acornEs);
+var _inject5 = require("acorn-static-class-property-initializer/inject");var _inject6 = _interopRequireDefault(_inject5);
+var _walk = require("acorn/dist/walk");var walk = _interopRequireWildcard(_walk);
+var _baseLexer = require("./base-lexer");var _baseLexer2 = _interopRequireDefault(_baseLexer);function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}function _interopRequireWildcard(obj) {if (obj && obj.__esModule) {return obj;} else {var newObj = {};if (obj != null) {for (var key in obj) {if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key];}}newObj.default = obj;return newObj;}}function _classCallCheck(instance, Constructor) {if (!(instance instanceof Constructor)) {throw new TypeError("Cannot call a class as a function");}}function _possibleConstructorReturn(self, call) {if (!self) {throw new ReferenceError("this hasn't been initialised - super() hasn't been called");}return call && (typeof call === "object" || typeof call === "function") ? call : self;}function _inherits(subClass, superClass) {if (typeof superClass !== "function" && superClass !== null) {throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);}subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } });if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;}var
 
 JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
   function JavascriptLexer() {var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};_classCallCheck(this, JavascriptLexer);var _this = _possibleConstructorReturn(this, (JavascriptLexer.__proto__ || Object.getPrototypeOf(JavascriptLexer)).call(this,
@@ -9,13 +13,30 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
     _this.acornOptions = _extends({ sourceType: 'module' }, options.acorn);
     _this.functions = options.functions || ['t'];
     _this.attr = options.attr || 'i18nKey';return _this;
-  }_createClass(JavascriptLexer, [{ key: 'extract', value: function extract(
+  }_createClass(JavascriptLexer, [{ key: "extract", value: function extract(
 
     content) {
       var that = this;
 
+      var localAcorn = acorn;
+
+      if (this.acornOptions.plugins) {
+        if (this.acornOptions.plugins.stage3) {
+          localAcorn = (0, _inject2.default)(localAcorn);
+        }
+        if (this.acornOptions.plugins.es7) {
+          (0, _acornEs2.default)(localAcorn);
+        }
+        if (this.acornOptions.plugins.staticClassPropertyInitializer) {
+          (0, _inject6.default)(localAcorn);
+        }
+        if (this.acornOptions.plugins.objectRestSpread) {
+          (0, _inject4.default)(localAcorn);
+        }
+      }
+
       walk.simple(
-      acorn.parse(content, this.acornOptions),
+      localAcorn.parse(content, this.acornOptions),
       {
         CallExpression: function CallExpression(node) {
           that.expressionExtractor.call(that, node);
@@ -24,7 +45,7 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
 
 
       return this.keys;
-    } }, { key: 'expressionExtractor', value: function expressionExtractor(
+    } }, { key: "expressionExtractor", value: function expressionExtractor(
 
     node) {
       var entry = {};
@@ -43,14 +64,14 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
         if (keyArgument && keyArgument.type === 'BinaryExpression') {
           var concatenatedString = this.concatenateString(keyArgument);
           if (!concatenatedString) {
-            this.emit('warning', 'Key is not a string literal: ' + keyArgument.name);
+            this.emit('warning', "Key is not a string literal: " + keyArgument.name);
             return;
           }
           entry.key = concatenatedString;
         } else
         {
           if (keyArgument.type === 'Identifier') {
-            this.emit('warning', 'Key is not a string literal: ' + keyArgument.name);
+            this.emit('warning', "Key is not a string literal: " + keyArgument.name);
           }
 
           return;
@@ -70,7 +91,7 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
 
         this.keys.push(entry);
       }
-    } }, { key: 'concatenateString', value: function concatenateString(
+    } }, { key: "concatenateString", value: function concatenateString(
 
     binaryExpression) {var string = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
       if (binaryExpression.operator !== '+') {
@@ -98,4 +119,4 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
       }
 
       return string;
-    } }]);return JavascriptLexer;}(_baseLexer2.default);exports.default = JavascriptLexer;module.exports = exports['default'];
+    } }]);return JavascriptLexer;}(_baseLexer2.default);exports.default = JavascriptLexer;module.exports = exports["default"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "i18next-parser",
-  "version": "1.0.0-beta20",
+  "version": "1.0.0-beta21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,30 +13,6 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
       "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
-    },
-    "acorn-bigint": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-bigint/-/acorn-bigint-0.2.0.tgz",
-      "integrity": "sha1-D0WlKQU3eZo7BwhWiaGGiBy1N4Q=",
-      "requires": {
-        "acorn": "5.5.3"
-      }
-    },
-    "acorn-class-fields": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.1.2.tgz",
-      "integrity": "sha1-IHgvMEr0Ilf+/1vUpcM1KRRzv1g=",
-      "requires": {
-        "acorn": "5.5.3"
-      }
-    },
-    "acorn-dynamic-import": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
-      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
-      "requires": {
-        "acorn": "5.5.3"
-      }
     },
     "acorn-es7": {
       "version": "0.1.0",
@@ -53,22 +29,6 @@
         }
       }
     },
-    "acorn-import-meta": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/acorn-import-meta/-/acorn-import-meta-0.2.1.tgz",
-      "integrity": "sha512-+KB5Q0P0Q/XpsPHgnLx4XbCGqMogw4yiJJjYsbzPCNrE/IoX+c6J4C+BFcwdWh3CD1zLzMxPITN1jzHd+NiS3w==",
-      "requires": {
-        "acorn": "5.5.3"
-      }
-    },
-    "acorn-json-superset": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-json-superset/-/acorn-json-superset-0.1.0.tgz",
-      "integrity": "sha1-tbkRoXd+pjpI/PxkNT54cwXoqUU=",
-      "requires": {
-        "acorn": "5.5.3"
-      }
-    },
     "acorn-jsx": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
@@ -77,58 +37,10 @@
         "acorn": "5.5.3"
       }
     },
-    "acorn-numeric-separator": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.1.1.tgz",
-      "integrity": "sha1-qkVaHZWuiHIx3pfgaBq74osGXo0=",
-      "requires": {
-        "acorn": "5.5.3"
-      }
-    },
     "acorn-object-rest-spread": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/acorn-object-rest-spread/-/acorn-object-rest-spread-1.1.0.tgz",
       "integrity": "sha1-eGma790Y7DGCyq2t9S4ml8BI9HY=",
-      "requires": {
-        "acorn": "5.5.3"
-      }
-    },
-    "acorn-optional-catch-binding": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-optional-catch-binding/-/acorn-optional-catch-binding-0.1.0.tgz",
-      "integrity": "sha1-2aGHTb/84es0lYNuXnWyrZwwCGg=",
-      "requires": {
-        "acorn": "5.5.3"
-      }
-    },
-    "acorn-private-methods": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.1.1.tgz",
-      "integrity": "sha1-MsE88k0Fvxyb4EkUtBSRxZ11oZU=",
-      "requires": {
-        "acorn": "5.5.3"
-      }
-    },
-    "acorn-stage3": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/acorn-stage3/-/acorn-stage3-0.6.0.tgz",
-      "integrity": "sha512-/CZrHonJfg5OSTkZ71w4L4JnpsqZyDIXaSot5gUpQriTUavjiuAjkJBxxNGtxTlGBVtOBtYwzqxLDUSOD3amDQ==",
-      "requires": {
-        "acorn": "5.5.3",
-        "acorn-bigint": "0.2.0",
-        "acorn-class-fields": "0.1.2",
-        "acorn-dynamic-import": "3.0.0",
-        "acorn-import-meta": "0.2.1",
-        "acorn-json-superset": "0.1.0",
-        "acorn-numeric-separator": "0.1.1",
-        "acorn-optional-catch-binding": "0.1.0",
-        "acorn-private-methods": "0.1.1"
-      }
-    },
-    "acorn-static-class-property-initializer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-static-class-property-initializer/-/acorn-static-class-property-initializer-1.0.0.tgz",
-      "integrity": "sha1-1JHdCMV63mbE2GgjZSajP128zBA=",
       "requires": {
         "acorn": "5.5.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,121 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
       "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
     },
+    "acorn-bigint": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-bigint/-/acorn-bigint-0.2.0.tgz",
+      "integrity": "sha1-D0WlKQU3eZo7BwhWiaGGiBy1N4Q=",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-class-fields": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.1.2.tgz",
+      "integrity": "sha1-IHgvMEr0Ilf+/1vUpcM1KRRzv1g=",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-dynamic-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-es7": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-es7/-/acorn-es7-0.1.0.tgz",
+      "integrity": "sha1-Sm3kUi+qy0wxIJ4bc7XzAe0rswo=",
+      "requires": {
+        "acorn": "2.7.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+        }
+      }
+    },
+    "acorn-import-meta": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/acorn-import-meta/-/acorn-import-meta-0.2.1.tgz",
+      "integrity": "sha512-+KB5Q0P0Q/XpsPHgnLx4XbCGqMogw4yiJJjYsbzPCNrE/IoX+c6J4C+BFcwdWh3CD1zLzMxPITN1jzHd+NiS3w==",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-json-superset": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-json-superset/-/acorn-json-superset-0.1.0.tgz",
+      "integrity": "sha1-tbkRoXd+pjpI/PxkNT54cwXoqUU=",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
     "acorn-jsx": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-numeric-separator": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.1.1.tgz",
+      "integrity": "sha1-qkVaHZWuiHIx3pfgaBq74osGXo0=",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-object-rest-spread": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-object-rest-spread/-/acorn-object-rest-spread-1.1.0.tgz",
+      "integrity": "sha1-eGma790Y7DGCyq2t9S4ml8BI9HY=",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-optional-catch-binding": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-optional-catch-binding/-/acorn-optional-catch-binding-0.1.0.tgz",
+      "integrity": "sha1-2aGHTb/84es0lYNuXnWyrZwwCGg=",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-private-methods": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.1.1.tgz",
+      "integrity": "sha1-MsE88k0Fvxyb4EkUtBSRxZ11oZU=",
+      "requires": {
+        "acorn": "5.5.3"
+      }
+    },
+    "acorn-stage3": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/acorn-stage3/-/acorn-stage3-0.6.0.tgz",
+      "integrity": "sha512-/CZrHonJfg5OSTkZ71w4L4JnpsqZyDIXaSot5gUpQriTUavjiuAjkJBxxNGtxTlGBVtOBtYwzqxLDUSOD3amDQ==",
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-bigint": "0.2.0",
+        "acorn-class-fields": "0.1.2",
+        "acorn-dynamic-import": "3.0.0",
+        "acorn-import-meta": "0.2.1",
+        "acorn-json-superset": "0.1.0",
+        "acorn-numeric-separator": "0.1.1",
+        "acorn-optional-catch-binding": "0.1.0",
+        "acorn-private-methods": "0.1.1"
+      }
+    },
+    "acorn-static-class-property-initializer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-static-class-property-initializer/-/acorn-static-class-property-initializer-1.0.0.tgz",
+      "integrity": "sha1-1JHdCMV63mbE2GgjZSajP128zBA=",
       "requires": {
         "acorn": "5.5.3"
       }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "acorn-es7": "^0.1.0",
     "acorn-jsx": "^4.1.1",
     "acorn-object-rest-spread": "^1.1.0",
-    "acorn-stage3": "^0.6.0",
-    "acorn-static-class-property-initializer": "^1.0.0",
     "broccoli-plugin": "^1.3.0",
     "cheerio": "^1.0.0-rc.2",
     "colors": "~1.2.0-rc0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
   },
   "dependencies": {
     "acorn": "^5.5.3",
+    "acorn-es7": "^0.1.0",
     "acorn-jsx": "^4.1.1",
+    "acorn-object-rest-spread": "^1.1.0",
+    "acorn-stage3": "^0.6.0",
+    "acorn-static-class-property-initializer": "^1.0.0",
     "broccoli-plugin": "^1.3.0",
     "cheerio": "^1.0.0-rc.2",
     "colors": "~1.2.0-rc0",

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -1,8 +1,6 @@
 import * as acorn from 'acorn-jsx'
-import injectAcornStage3 from "acorn-stage3/inject"
 import injectAcornObjectRestSpread from "acorn-object-rest-spread/inject"
 import injectAcornEs7 from "acorn-es7"
-import injectAcornStaticClassPropertyInitializer from "acorn-static-class-property-initializer/inject"
 import * as walk from 'acorn/dist/walk'
 import BaseLexer from './base-lexer'
 
@@ -21,14 +19,8 @@ export default class JavascriptLexer extends BaseLexer {
     let localAcorn = acorn
 
     if (this.acornOptions.plugins) {
-      if (this.acornOptions.plugins.stage3) {
-        localAcorn = injectAcornStage3(localAcorn)
-      }
       if (this.acornOptions.plugins.es7) {
         injectAcornEs7(localAcorn)
-      }
-      if (this.acornOptions.plugins.staticClassPropertyInitializer) {
-        injectAcornStaticClassPropertyInitializer(localAcorn)
       }
       if (this.acornOptions.plugins.objectRestSpread) {
         injectAcornObjectRestSpread(localAcorn)

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -1,4 +1,8 @@
 import * as acorn from 'acorn-jsx'
+import injectAcornStage3 from "acorn-stage3/inject"
+import injectAcornObjectRestSpread from "acorn-object-rest-spread/inject"
+import injectAcornEs7 from "acorn-es7"
+import injectAcornStaticClassPropertyInitializer from "acorn-static-class-property-initializer/inject"
 import * as walk from 'acorn/dist/walk'
 import BaseLexer from './base-lexer'
 
@@ -14,8 +18,21 @@ export default class JavascriptLexer extends BaseLexer {
   extract(content) {
     const that = this
 
+    var localAcorn = acorn;
+
+    if(this.acornOptions.plugins) {
+      if(this.acornOptions.plugins.stage3)
+        localAcorn = injectAcornStage3(localAcorn);
+      if(this.acornOptions.plugins.es7)
+        injectAcornEs7(localAcorn);
+      if(this.acornOptions.plugins.staticClassPropertyInitializer)
+        injectAcornStaticClassPropertyInitializer(localAcorn);
+      if(this.acornOptions.plugins.objectRestSpread)
+        injectAcornObjectRestSpread(localAcorn);
+    }
+
     walk.simple(
-      acorn.parse(content, this.acornOptions),
+      localAcorn.parse(content, this.acornOptions),
       {
         CallExpression(node) {
           that.expressionExtractor.call(that, node)

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -18,17 +18,21 @@ export default class JavascriptLexer extends BaseLexer {
   extract(content) {
     const that = this
 
-    var localAcorn = acorn;
+    let localAcorn = acorn
 
-    if(this.acornOptions.plugins) {
-      if(this.acornOptions.plugins.stage3)
-        localAcorn = injectAcornStage3(localAcorn);
-      if(this.acornOptions.plugins.es7)
-        injectAcornEs7(localAcorn);
-      if(this.acornOptions.plugins.staticClassPropertyInitializer)
-        injectAcornStaticClassPropertyInitializer(localAcorn);
-      if(this.acornOptions.plugins.objectRestSpread)
-        injectAcornObjectRestSpread(localAcorn);
+    if (this.acornOptions.plugins) {
+      if (this.acornOptions.plugins.stage3) {
+        localAcorn = injectAcornStage3(localAcorn)
+      }
+      if (this.acornOptions.plugins.es7) {
+        injectAcornEs7(localAcorn)
+      }
+      if (this.acornOptions.plugins.staticClassPropertyInitializer) {
+        injectAcornStaticClassPropertyInitializer(localAcorn)
+      }
+      if (this.acornOptions.plugins.objectRestSpread) {
+        injectAcornObjectRestSpread(localAcorn)
+      }
     }
 
     walk.simple(

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -84,4 +84,23 @@ describe('JavascriptLexer', () => {
     ])
     done()
   })
+
+  it('supports the acorn-es7 plugin', (done) => {
+    const Lexer = new JavascriptLexer({ acorn: { plugins: { es7: true } } })
+    const content = '@decorator() class Test { test() { t("foo") } }'
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'foo' }
+    ])
+    done()
+  })
+
+  it('supports the acorn-object-rest-spread plugin', (done) => {
+    const Lexer = new JavascriptLexer({ acorn: { plugins: { objectRestSpread: true } } })
+    const content = 'const data = { text: t("foo"), ...rest }; const { text, ...more } = data;'
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'foo' }
+    ])
+    done()
+  })
+
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,11 +10,99 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+acorn-bigint@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-bigint/-/acorn-bigint-0.2.0.tgz#0f45a5290537799a3b07085689a186881cb53784"
+  dependencies:
+    acorn "^5.2.1"
+
+acorn-class-fields@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/acorn-class-fields/-/acorn-class-fields-0.1.2.tgz#20782f304af42257feff5bd4a5c335291473bf58"
+  dependencies:
+    acorn "^5.3.0"
+
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  dependencies:
+    acorn "^5.0.0"
+
+acorn-es7@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-es7/-/acorn-es7-0.1.0.tgz#4a6de4522faacb4c31209e1b73b5f301ed2bb30a"
+  dependencies:
+    acorn "^2.6.4"
+
+acorn-import-meta@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/acorn-import-meta/-/acorn-import-meta-0.2.1.tgz#ac91e06e00facece7e96ff76a0fe9ec7b1cb5b5c"
+  dependencies:
+    acorn "^5.4.1"
+
+acorn-json-superset@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-json-superset/-/acorn-json-superset-0.1.0.tgz#b5b911a1777ea63a48fcfc64353e787305e8a945"
+  dependencies:
+    acorn "^5.4.1"
+
 acorn-jsx@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
   dependencies:
     acorn "^5.0.3"
+
+acorn-numeric-separator@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-numeric-separator/-/acorn-numeric-separator-0.1.1.tgz#aa455a1d95ae887231de97e0681abbe28b065e8d"
+  dependencies:
+    acorn "^5.2.1"
+
+acorn-object-rest-spread@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-object-rest-spread/-/acorn-object-rest-spread-1.1.0.tgz#78699aefdd18ec3182caadadf52e2697c048f476"
+  dependencies:
+    acorn "^5.0.3"
+
+acorn-optional-catch-binding@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-optional-catch-binding/-/acorn-optional-catch-binding-0.1.0.tgz#d9a1874dbffce1eb3495836e5e75b2ad9c300868"
+  dependencies:
+    acorn "^5.2.1"
+
+acorn-private-methods@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-private-methods/-/acorn-private-methods-0.1.1.tgz#32c13cf24d05bf1c9be04914b41491c59d75a195"
+  dependencies:
+    acorn "^5.4.0"
+
+acorn-stage3@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/acorn-stage3/-/acorn-stage3-0.6.0.tgz#d2814cec8e2f8bcb0407ba657fbe0cfb118f9bc2"
+  dependencies:
+    acorn "^5.5.0"
+    acorn-bigint "^0.2.0"
+    acorn-class-fields "^0.1.1"
+    acorn-dynamic-import "^3.0.0"
+    acorn-import-meta "^0.2.1"
+    acorn-json-superset "^0.1.0"
+    acorn-numeric-separator "^0.1.1"
+    acorn-optional-catch-binding "^0.1.0"
+    acorn-private-methods "^0.1.1"
+
+acorn-static-class-property-initializer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-static-class-property-initializer/-/acorn-static-class-property-initializer-1.0.0.tgz#d491dd08c57ade66c4d868236526a33f5dbccc10"
+  dependencies:
+    acorn "^5.0.3"
+
+acorn@^2.6.4:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
+
+acorn@^5.0.0, acorn@^5.2.1, acorn@^5.3.0, acorn@^5.4.0, acorn@^5.4.1, acorn@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 acorn@^5.0.3, acorn@^5.5.3:
   version "5.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,41 +10,11 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-acorn-bigint@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-bigint/-/acorn-bigint-0.2.0.tgz#0f45a5290537799a3b07085689a186881cb53784"
-  dependencies:
-    acorn "^5.2.1"
-
-acorn-class-fields@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/acorn-class-fields/-/acorn-class-fields-0.1.2.tgz#20782f304af42257feff5bd4a5c335291473bf58"
-  dependencies:
-    acorn "^5.3.0"
-
-acorn-dynamic-import@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
-  dependencies:
-    acorn "^5.0.0"
-
 acorn-es7@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/acorn-es7/-/acorn-es7-0.1.0.tgz#4a6de4522faacb4c31209e1b73b5f301ed2bb30a"
   dependencies:
     acorn "^2.6.4"
-
-acorn-import-meta@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/acorn-import-meta/-/acorn-import-meta-0.2.1.tgz#ac91e06e00facece7e96ff76a0fe9ec7b1cb5b5c"
-  dependencies:
-    acorn "^5.4.1"
-
-acorn-json-superset@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-json-superset/-/acorn-json-superset-0.1.0.tgz#b5b911a1777ea63a48fcfc64353e787305e8a945"
-  dependencies:
-    acorn "^5.4.1"
 
 acorn-jsx@^4.1.1:
   version "4.1.1"
@@ -52,57 +22,15 @@ acorn-jsx@^4.1.1:
   dependencies:
     acorn "^5.0.3"
 
-acorn-numeric-separator@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/acorn-numeric-separator/-/acorn-numeric-separator-0.1.1.tgz#aa455a1d95ae887231de97e0681abbe28b065e8d"
-  dependencies:
-    acorn "^5.2.1"
-
 acorn-object-rest-spread@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/acorn-object-rest-spread/-/acorn-object-rest-spread-1.1.0.tgz#78699aefdd18ec3182caadadf52e2697c048f476"
   dependencies:
     acorn "^5.0.3"
 
-acorn-optional-catch-binding@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-optional-catch-binding/-/acorn-optional-catch-binding-0.1.0.tgz#d9a1874dbffce1eb3495836e5e75b2ad9c300868"
-  dependencies:
-    acorn "^5.2.1"
-
-acorn-private-methods@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/acorn-private-methods/-/acorn-private-methods-0.1.1.tgz#32c13cf24d05bf1c9be04914b41491c59d75a195"
-  dependencies:
-    acorn "^5.4.0"
-
-acorn-stage3@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/acorn-stage3/-/acorn-stage3-0.6.0.tgz#d2814cec8e2f8bcb0407ba657fbe0cfb118f9bc2"
-  dependencies:
-    acorn "^5.5.0"
-    acorn-bigint "^0.2.0"
-    acorn-class-fields "^0.1.1"
-    acorn-dynamic-import "^3.0.0"
-    acorn-import-meta "^0.2.1"
-    acorn-json-superset "^0.1.0"
-    acorn-numeric-separator "^0.1.1"
-    acorn-optional-catch-binding "^0.1.0"
-    acorn-private-methods "^0.1.1"
-
-acorn-static-class-property-initializer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-static-class-property-initializer/-/acorn-static-class-property-initializer-1.0.0.tgz#d491dd08c57ade66c4d868236526a33f5dbccc10"
-  dependencies:
-    acorn "^5.0.3"
-
 acorn@^2.6.4:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
-
-acorn@^5.0.0, acorn@^5.2.1, acorn@^5.3.0, acorn@^5.4.0, acorn@^5.4.1, acorn@^5.5.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 acorn@^5.0.3, acorn@^5.5.3:
   version "5.5.3"
@@ -2568,7 +2496,7 @@ lodash@^4.15.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
-lodash@^4.17.4, lodash@~4.17.4:
+lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Follow-up of #108 

This pull request enables i18next-parser to make use of acorn's additional JS plugins acorn-es7 and acorn-acorn-object-rest-spread.

All tests pass properly, and new plugins are only loaded if necessary. Stage3 and static class properties have been backed out by now.