### PR TITLE
Remove `extension` and `filename` options in favor all path config in `output`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ gulp.task('i18next', function() {
   gulp.src('app/**')
     .pipe(new i18nextParser({
       locales: ['en', 'de'],
-      output: 'locales'
+      output: 'locales/$LOCALE/$NAMESPACE.json'
     }))
     .pipe(gulp.dest('./'));
 });
@@ -92,7 +92,7 @@ let i18n = new Funnel(appRoot, {
 })
 
 i18n = new i18nextParser([i18n], {
-  output: 'broccoli/locales'
+  output: 'broccoli/locales/$LOCALE/$NAMESPACE.json'
 })
 
 module.exports = i18n

--- a/README.md
+++ b/README.md
@@ -118,14 +118,6 @@ module.exports = {
   "defaultValue": "",
   // Default value to give to empty keys                   
 
-  "extension": ".json",
-  // Extension of the catalogs 
-  // Supports $LOCALE and $NAMESPACE injection
-
-  "filename": "$NAMESPACE",
-  // Filename of the catalogs                              
-  // Supports $LOCALE and $NAMESPACE injection
-
   "indentation": 2,
   // Indentation of the catalog files                      
 
@@ -161,7 +153,8 @@ module.exports = {
   // Namespace separator used in your translation keys   
   // If you want to use plain english keys, separators such as `.` and `:` will conflict. You might want to set `keySeparator: false` and `namespaceSeparator: false`. That way, `t('Status: Loading...')` will not think that there are a namespace and three separator dots for instance.
 
-  "output": "locales",
+  "output": "locales/$LOCALE/$NAMESPACE.json",
+  // Supports $LOCALE and $NAMESPACE injection
   // Where to write the locale files relative to the base
 
   "input": undefined,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12,7 +12,7 @@ var vfs           = require('vinyl-fs')
 program
 .version(pkg.version)
 .option('-c, --config <path>', 'Path to the config file (default: i18next-scanner.config.js)')
-.option('-o, --output <path>', 'Path to the output directory (default: locales)')
+.option('-o, --output <path>', 'Path to the output directory (default: locales/$LOCALE/$NAMESPACE.json)')
 .option('-s, --silent', 'Disable logging to stdout')
 
 program.on('--help', function() {
@@ -20,7 +20,7 @@ program.on('--help', function() {
   console.log('')
   console.log('    $ i18next "src/**/*.{js,jsx}"')
   console.log('    $ i18next "/path/to/src/app.js" "/path/to/assets/index.html"')
-  console.log('    $ i18next --config i18next-parser.config.js --output /path/to/output \'src/**/*.{js,jsx}\'')
+  console.log('    $ i18next --config i18next-parser.config.js --output locales/$LOCALE/$NAMESPACE.json \'src/**/*.{js,jsx}\'')
   console.log('')
 })
 

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -29,7 +29,7 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
       lineEnding: 'auto',
       locales: ['en', 'fr'],
       namespaceSeparator: ':',
-      output: 'locales',
+      output: 'locales/$LOCALE/$NAMESPACE.json',
       reactNamespace: false,
       sort: false,
       verbose: false };
@@ -138,7 +138,7 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
 
             var parsedNamespacePath = _path2.default.parse(namespacePath);
 
-            var namespaceOldPath = parsedNamespacePath.dir + parsedNamespacePath.name + '_old' + parsedNamespacePath.ext;
+            var namespaceOldPath = _path2.default.join(parsedNamespacePath.dir, parsedNamespacePath.name + '_old' + parsedNamespacePath.ext);
 
             var existingCatalog = this.getCatalog(namespacePath);
             var existingOldCatalog = this.getCatalog(namespaceOldPath);

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -22,8 +22,6 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
       createOldCatalogs: true,
       defaultNamespace: 'translation',
       defaultValue: '',
-      extension: '.json',
-      filename: '$NAMESPACE',
       indentation: 2,
       keepRemoved: false,
       keySeparator: '.',
@@ -131,22 +129,16 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
       }var _iteratorNormalCompletion3 = true;var _didIteratorError3 = false;var _iteratorError3 = undefined;try {
 
         for (var _iterator3 = this.options.locales[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {var locale = _step3.value;
-          var outputPath = _path2.default.resolve(this.options.output, locale);
+          var outputPath = _path2.default.resolve(this.options.output);
 
           for (var namespace in catalog) {
-            var filename = this.options.filename;
-            filename = filename.replace(this.localeRegex, locale);
-            filename = filename.replace(this.namespaceRegex, namespace);
+            var namespacePath = outputPath;
+            namespacePath = namespacePath.replace(this.localeRegex, locale);
+            namespacePath = namespacePath.replace(this.namespaceRegex, namespace);
 
-            var extension = this.options.extension;
-            extension = extension.replace(this.localeRegex, locale);
-            extension = extension.replace(this.namespaceRegex, namespace);
+            var parsedNamespacePath = _path2.default.parse(namespacePath);
 
-            var oldFilename = filename + '_old' + extension;
-            filename += extension;
-
-            var namespacePath = _path2.default.resolve(outputPath, filename);
-            var namespaceOldPath = _path2.default.resolve(outputPath, oldFilename);
+            var namespaceOldPath = parsedNamespacePath.dir + parsedNamespacePath.name + '_old' + parsedNamespacePath.ext;
 
             var existingCatalog = this.getCatalog(namespacePath);
             var existingOldCatalog = this.getCatalog(namespaceOldPath);

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,18 +4,18 @@
 
 Command line (the options are identical):
 
-`i18next /path/to/file/or/dir -o /output/directory`
+`i18next /path/to/file/or/dir -o /translations/$LOCALE/$NAMESPACE.json`
 
-`i18next /path/to/file/or/dir:/output/directory`
+`i18next /path/to/file/or/dir:/translations/$LOCALE/$NAMESPACE.json`
 
 Gulp:
 
-`.pipe(i18next({output: 'translations'}))`
+`.pipe(i18next({output: 'translations/$LOCALE/$NAMESPACE.json'}))`
 
 It will create the file in the specified folder (in case of gulp it doesn't actually create the files until you call `dest()`):
 
 ```
-/output/directory/en/translation.json
+/translations/en/translation.json
 ...
 ```
 
@@ -148,12 +148,10 @@ In recursive mode, it will parse `*.hbs` and `*.js` files and skip `.git` folder
 **Work with Meteor TAP-i18N (gulp)**
 
 `.pipe(i18next({
-    output: "i18n",
+    output: "i18n/$LOCALE/$NAMESPACE.$LOCALE.i18n.json",
     locales: ['en', 'de', 'fr', 'es'],
     functions: ['_'],
     namespace: 'client',
-    suffix: '.$LOCALE',
-    extension: ".i18n.json",
     writeOld: false
 }))`
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,6 +9,8 @@
 - `namespace` was renamed `defaultNamespace`. It defaults to `translation`.
 - `prefix` was deprecated. Use `output`
 - `suffix` was deprecated. Use `output`
+- `filename` was deprecated. Use `output`
+- `extension` was deprecated. Use `output`
 - catalogs are no longer sorted by default. Set `sort` to `true` to enable this.
 
 ## Improvements

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -7,14 +7,14 @@
 - `ignoreVariables` was deprecated. Keys that are not string litterals now emit a warning
 - `writeOld` was renamed `createOldLibraries`. It defaults to `true`.
 - `namespace` was renamed `defaultNamespace`. It defaults to `translation`.
-- `prefix` was deprecated. Use `filename`
-- `suffix` was deprecated. Use `filename`
+- `prefix` was deprecated. Use `output`
+- `suffix` was deprecated. Use `output`
 - catalogs are no longer sorted by default. Set `sort` to `true` to enable this.
 
 ## Improvements
 
 - `defaultValue`: replace empty keys with the given value
-- `filename` and `extension` support for `$NAMESPACE` and `$LOCALE` variables
+- `output` support for `$NAMESPACE` and `$LOCALE` variables
 - `indentation` let you control the indentation of the catalogs
 - `lineEnding` let you control the line ending of the catalogs
 - `sort` let you enable sorting.

--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  output: 'test/manual'
+  output: 'test/manual/$LOCALE/$NAMESPACE.json'
 };

--- a/issue_template.md
+++ b/issue_template.md
@@ -15,7 +15,7 @@ Here is my config file:
 ```
 {
   locales: ['en', 'de'],
-  output: '../locales'
+  output: 'locales/$LOCALE/$NAMESPACE.json'
 }
 ```
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -29,7 +29,7 @@ export default class i18nTransform extends Transform {
       lineEnding: 'auto',
       locales: ['en', 'fr'],
       namespaceSeparator: ':',
-      output: 'locales',
+      output: 'locales/$LOCALE/$NAMESPACE.json',
       reactNamespace: false,
       sort: false,
       verbose: false
@@ -138,7 +138,7 @@ export default class i18nTransform extends Transform {
 
         let parsedNamespacePath = path.parse(namespacePath)
 
-        const namespaceOldPath = parsedNamespacePath.dir + parsedNamespacePath.name + '_old' + parsedNamespacePath.ext
+        const namespaceOldPath = path.join(parsedNamespacePath.dir, `${parsedNamespacePath.name}_old${parsedNamespacePath.ext}`)
 
         let existingCatalog = this.getCatalog(namespacePath)
         let existingOldCatalog = this.getCatalog(namespaceOldPath)

--- a/src/transform.js
+++ b/src/transform.js
@@ -22,8 +22,6 @@ export default class i18nTransform extends Transform {
       createOldCatalogs: true,
       defaultNamespace: 'translation',
       defaultValue: '',
-      extension: '.json',
-      filename: '$NAMESPACE',
       indentation: 2,
       keepRemoved: false,
       keySeparator: '.',
@@ -131,22 +129,16 @@ export default class i18nTransform extends Transform {
     }
 
     for (const locale of this.options.locales) {
-      const outputPath = path.resolve(this.options.output, locale)
+      const outputPath = path.resolve(this.options.output)
 
       for (const namespace in catalog) {
-        let filename = this.options.filename
-        filename = filename.replace(this.localeRegex, locale)
-        filename = filename.replace(this.namespaceRegex, namespace)
+        let namespacePath = outputPath
+        namespacePath = namespacePath.replace(this.localeRegex, locale)
+        namespacePath = namespacePath.replace(this.namespaceRegex, namespace)
 
-        let extension = this.options.extension
-        extension = extension.replace(this.localeRegex, locale)
-        extension = extension.replace(this.namespaceRegex, namespace)
+        let parsedNamespacePath = path.parse(namespacePath)
 
-        const oldFilename = filename + '_old' + extension
-        filename += extension
-
-        const namespacePath = path.resolve(outputPath, filename)
-        const namespaceOldPath = path.resolve(outputPath, oldFilename)
+        const namespaceOldPath = parsedNamespacePath.dir + parsedNamespacePath.name + '_old' + parsedNamespacePath.ext
 
         let existingCatalog = this.getCatalog(namespacePath)
         let existingOldCatalog = this.getCatalog(namespaceOldPath)

--- a/test/Brocfile.js
+++ b/test/Brocfile.js
@@ -9,7 +9,7 @@ let i18n = new Funnel(appRoot, {
 })
 
 i18n = new i18nextParser([i18n], {
-  output: 'broccoli/locales'
+  output: 'broccoli/locales/$LOCALE/$NAMESPACE.json'
 })
 
 module.exports = i18n

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -5,7 +5,7 @@ gulp.task('i18next', function() {
   return gulp.src(['templating/*'])
     .pipe(new i18next({
         locales: ['en', 'fr'],
-        output: 'gulp/locales'
+        output: 'gulp/locales/$LOCALE/$NAMESPACE.json'
     }))
     .pipe(gulp.dest('./'));
 });

--- a/test/i18next-parser.config.js
+++ b/test/i18next-parser.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  output: 'manual'
+  output: 'manual/$LOCALE/$NAMESPACE.json'
 };

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -317,7 +317,7 @@ describe('parser', () => {
 
   it('retrieves values in existing catalog and creates old catalog', (done) => {
     let result, resultOld
-    const i18nextParser = new i18nTransform({ output: 'test/locales' })
+    const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
     const fakeFile = new Vinyl({
       contents: Buffer.from("t('test_merge:first'); t('test_merge:second')"),
       path: 'file.js'
@@ -343,7 +343,7 @@ describe('parser', () => {
   it('does not leak values between locales', (done) => {
     let resultEN
     let resultFR
-    const i18nextParser = new i18nTransform({ output: 'test/locales' })
+    const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
     const fakeFile = new Vinyl({
       contents: Buffer.from("t('test_leak:first'); t('test_leak:second')"),
       path: 'file.js'
@@ -368,7 +368,7 @@ describe('parser', () => {
 
   it('retrieves context values in existing catalog', (done) => {
     let result
-    const i18nextParser = new i18nTransform({ output: 'test/locales' })
+    const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
     const fakeFile = new Vinyl({
       contents: Buffer.from("t('test_context:first')"),
       path: 'file.js'
@@ -394,7 +394,7 @@ describe('parser', () => {
   })
 
   it('saves unused translations in the old catalog', (done) => {
-    const i18nextParser = new i18nTransform({ output: 'test/locales' })
+    const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
     const fakeFile = new Vinyl({
       contents: Buffer.from("t('test_old:parent.third', 'third'), t('test_old:fourth', 'fourth')"),
       path: 'file.js'
@@ -422,7 +422,7 @@ describe('parser', () => {
   })
 
   it('restores translations from the old catalog', (done) => {
-    const i18nextParser = new i18nTransform({ output: 'test/locales' })
+    const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
     const fakeFile = new Vinyl({
       contents: Buffer.from("t('test_old:parent.some', 'random'), t('test_old:other', 'random')"),
       path: 'file.js'
@@ -451,7 +451,7 @@ describe('parser', () => {
 
   it('retrieves plural values in existing catalog', (done) => {
     let result
-    const i18nextParser = new i18nTransform({ output: 'test/locales' })
+    const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
     const fakeFile = new Vinyl({
       contents: Buffer.from(
         "t('test_plural:first'); t('test_plural:second')"
@@ -482,7 +482,7 @@ describe('parser', () => {
 
   it('retrieves plural and context values in existing catalog', (done) => {
     let result
-    const i18nextParser = new i18nTransform({ output: 'test/locales' })
+    const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
     const fakeFile = new Vinyl({
       contents: Buffer.from("t('test_context_plural:first')"),
       path: 'file.js'
@@ -508,13 +508,12 @@ describe('parser', () => {
   })
 
   describe('options', () => {
-    it('handles filename and extension with $LOCALE and $NAMESPACE var', (done) => {
+    it('handles output with $LOCALE and $NAMESPACE var', (done) => {
       let result
       const i18nextParser = new i18nTransform({
         locales: ['en'],
         defaultNamespace: 'default',
-        filename: 'p-$LOCALE-$NAMESPACE',
-        extension: '.$LOCALE.i18n'
+        output: 'locales/$LOCALE/p-$LOCALE-$NAMESPACE.$LOCALE.i18n'
       })
       const fakeFile = new Vinyl({
         contents: Buffer.from("t('fourth')"),
@@ -695,7 +694,7 @@ describe('parser', () => {
     it('supports outputing to yml', (done) => {
       let result
       const i18nextParser = new i18nTransform({
-        extension: '.yml'
+        output: 'locales/$LOCALE/$NAMESPACE.yml'
       })
       const fakeFile = new Vinyl({
         contents: Buffer.from("t('first')"),
@@ -878,7 +877,7 @@ describe('parser', () => {
     })
 
     it('emits a `error` event if the catalog is not valid json', (done) => {
-      const i18nextParser = new i18nTransform({ output: 'test/locales' })
+      const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
       const fakeFile = new Vinyl({
         contents: Buffer.from("t('test_invalid:content')"),
         path: 'file.js'
@@ -907,7 +906,7 @@ describe('parser', () => {
     })
 
     it('emits a `warning` event if a key contains a variable', (done) => {
-      const i18nextParser = new i18nTransform({ output: 'test/locales' })
+      const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
       const fakeFile = new Vinyl({
         contents: Buffer.from('t(variable)'),
         path: 'file.js'
@@ -921,7 +920,7 @@ describe('parser', () => {
     })
 
     it('emits a `warning` event if a react value contains two variables', (done) => {
-      const i18nextParser = new i18nTransform({ output: 'test/locales' })
+      const i18nextParser = new i18nTransform({ output: 'test/locales/$LOCALE/$NAMESPACE.json' })
       const fakeFile = new Vinyl({
         contents: Buffer.from('<Trans>{{ key1, key2 }}</Trans>'),
         path: 'file.js'


### PR DESCRIPTION
Wow that was a lot of changes. 

Most of them are documentation (or reference) and test changes. The only actual code change happened in transform.js, and it's pretty minimal. Note that we're relying on node's `path.resolve` to turn 'this/that/thou' into window's-style paths if we're on a windows machine.

Every test that used a customized extension, filename or output needed to be tweaked. That accounts for all the changes to the tests that aren't renames.

The documentation and reference changes I made *seem* correct, but I'm not as familiar with the history of the project.