### PR TITLE
fix(ts): don't parse tsx for plain ts files

### DIFF
--- a/dist/lexers/typescript-lexer.js
+++ b/dist/lexers/typescript-lexer.js
@@ -20,7 +20,7 @@ TypescriptLexer = function (_JsxLexer) {_inherits(TypescriptLexer, _JsxLexer);
       var transpiled = this.typescript.transpileModule(content, {
         compilerOptions: _extends({},
         this.tsOptions, {
-          jsx: 'Preserve',
+          jsx: extension === 'ts' ? false : 'Preserve',
           target: 'esnext' }) });
 
 

--- a/dist/parser.js
+++ b/dist/parser.js
@@ -66,7 +66,7 @@ Parser = function (_EventEmitter) {_inherits(Parser, _EventEmitter);
 
           var Lexer = new lexersMap[lexerName](lexerOptions);
           Lexer.on('warning', function (warning) {return _this2.emit('warning', warning);});
-          keys = keys.concat(Lexer.extract(content));
+          keys = keys.concat(Lexer.extract(content, extension));
         }} catch (err) {_didIteratorError = true;_iteratorError = err;} finally {try {if (!_iteratorNormalCompletion && _iterator.return) {_iterator.return();}} finally {if (_didIteratorError) {throw _iteratorError;}}}
 
       return keys;

--- a/src/lexers/typescript-lexer.js
+++ b/src/lexers/typescript-lexer.js
@@ -20,7 +20,7 @@ export default class TypescriptLexer extends JsxLexer {
     const transpiled = this.typescript.transpileModule(content, {
       compilerOptions: {
         ...this.tsOptions,
-        jsx: 'Preserve',
+        jsx: extension === 'ts' ? false : 'Preserve',
         target: 'esnext'
       }
     })

--- a/src/parser.js
+++ b/src/parser.js
@@ -66,7 +66,7 @@ export default class Parser extends EventEmitter {
 
       const Lexer = new lexersMap[lexerName](lexerOptions)
       Lexer.on('warning', warning => this.emit('warning', warning))
-      keys = keys.concat(Lexer.extract(content))
+      keys = keys.concat(Lexer.extract(content, extension))
     }
 
     return keys


### PR DESCRIPTION
TypeScript is slightly incompatible in some cases with tsx, which led to parse errors for some of our files when it read ts as tsx. This checks the extension and only parses to tsx when appropriate.