### PR TITLE
FIX CLI options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Multiple globbing patterns are supported to specify complex file selections. You
 
 **IMPORTANT NOTE**: If you pass the globs as CLI argument, they must be relative to where you run the command (aka relative to `process.cwd()`). If you pass the globs via the `input` option of the config file, they must be relative to the config file. 
 
-- **-c, --config <path>**: Path to the output directory (default: locales/$LOCALE/$NAMESPACE.json)
-- **-o, --output <path>**: Where to write the locale files.
+- **-c, --config <path>**: Path to the config file (default: i18next-parser.config.js).
+- **-o, --output <path>**: Path to the output directory (default: locales/$LOCALE/$NAMESPACE.json).
 - **-S, --silent**: Disable logging to stdout.
 
 ### Gulp


### PR DESCRIPTION
There was bad description about `--config` option in CLI.

I copy & paste description from cli itself (https://github.com/i18next/i18next-parser/blob/a9b843504faf31d0573ba83ee113dc1296afb408/bin/cli.js#L14-L16)