### PR TITLE
Add support for jsx-fragments

### DIFF
--- a/dist/lexers/jsx-lexer.js
+++ b/dist/lexers/jsx-lexer.js
@@ -8,6 +8,9 @@ var JSXParserExtension = {
   JSXEmptyExpression: function JSXEmptyExpression(node, st, c) {
     // We need this catch, but we don't need the catch to do anything.
   },
+  JSXFragment: function JSXFragment(node, st, c) {
+    node.children.forEach(function (child) {return c(child, st, child.type);});
+  },
   JSXElement: function JSXElement(node, st, c) {
     node.openingElement.attributes.forEach(function (attr) {return c(attr, st, attr.type);});
     node.children.forEach(function (child) {return c(child, st, child.type);});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Karel Ledru",
   "description": "Command Line tool for i18next",
   "name": "i18next-parser",
-  "version": "1.0.0-beta31",
+  "version": "1.0.0-beta30",
   "license": "MIT",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Karel Ledru",
   "description": "Command Line tool for i18next",
   "name": "i18next-parser",
-  "version": "1.0.0-beta30",
+  "version": "1.0.0-beta31",
   "license": "MIT",
   "main": "dist/index.js",
   "bin": {

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -8,6 +8,9 @@ const JSXParserExtension = {
   JSXEmptyExpression(node, st, c) {
     // We need this catch, but we don't need the catch to do anything.
   },
+  JSXFragment(node, st, c) {
+    node.children.forEach(child => c(child, st, child.type));
+  },
   JSXElement(node, st, c) {
     node.openingElement.attributes.forEach(attr => c(attr, st, attr.type))
     node.children.forEach(child => c(child, st, child.type))

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -103,6 +103,15 @@ describe('JsxLexer', () => {
       assert.equal(Lexer.extract(content)[0].defaultValue, 'Some Content')
       done()
     })
+
+    it('handles jsx fragments', (done) => {
+      const Lexer = new JsxLexer()
+      const content = '<><Trans i18nKey="first" /></>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'first' }
+      ])
+      done()
+    })
   })
   describe('supports additional plugins via injector option', () => {
     it('provided injectors are called with acorn', (done) => {


### PR DESCRIPTION
Fragment shorthand syntax, is currently not supported.  This PR adds support

```
<>Test</>
```