### PR TITLE
feature/use-default-separator: use config keySeparator value

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,7 +11,7 @@ function dotPathToHash(entry, target = {}, options = {}) {
   const separator = options.separator || '.'
   let newValue = entry.defaultValue || entry.defaultValue || options.value || ''
   if (options.useKeysAsDefaultValue) {
-    newValue = entry.key.substring(entry.key.indexOf('.') + 1, entry.key.length)
+    newValue = entry.key.substring(entry.key.indexOf(separator) + separator.length, entry.key.length)
   }
 
   if (path.endsWith(separator)) {

--- a/test/helpers/dotPathToHash.test.js
+++ b/test/helpers/dotPathToHash.test.js
@@ -57,6 +57,45 @@ describe('dotPathToHash helper function', () => {
     done()
   })
 
+  it('handles falsey `useKeysAsDefaultValue` with `separator` option exist in key', (done) => {
+    const { target } = dotPathToHash(
+      { key: 'one_two_three.' },
+      {},
+      {
+        useKeysAsDefaultValue: false,
+        separator: '_',
+      },
+    )
+    assert.deepEqual(target, { one: { two: { 'three.': '' } } })
+    done()
+  })
+
+  it('handles falsey `useKeysAsDefaultValue` with `separator` option not exist in key', (done) => {
+    const { target } = dotPathToHash(
+      { key: 'one.two.three.' },
+      {},
+      {
+        useKeysAsDefaultValue: false,
+        separator: '_',
+      },
+    )
+    assert.deepEqual(target, { 'one.two.three.': '' })
+    done()
+  })
+
+  it('handles `useKeysAsDefaultValue` with `separator` option', (done) => {
+    const { target } = dotPathToHash(
+      { key: 'one.two.three.' },
+      {},
+      {
+        useKeysAsDefaultValue: true,
+        separator: '_',
+      },
+    )
+    assert.deepEqual(target, { 'one.two.three.': 'one.two.three.' })
+    done()
+  })
+
   it('detects duplicate keys with the same value', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
       { key: 'one.two.three' },

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -833,7 +833,7 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
-    it.only('supports useKeysAsDefaultValue', (done) => {
+    it('supports useKeysAsDefaultValue', (done) => {
       let result
       const i18nextParser = new i18nTransform({
         useKeysAsDefaultValue: true,
@@ -851,9 +851,9 @@ describe('parser', () => {
         }
       })
       i18nextParser.on('end', () => {
-        assert.deepEqual(result, { 
-          first: 'first', 
-          'second and third': 'second and third', 
+        assert.deepEqual(result, {
+          first: 'first',
+          'second and third': 'second and third',
           '$fourth %fifth%': '$fourth %fifth%',
           six: {
             seven: 'six.seven'


### PR DESCRIPTION
The separator is being set [here](https://github.com/i18next/i18next-parser/blob/master/src/helpers.js#L11).

It being set to the key coming from the config file (`i18next-parser.config.js`) and default it to a dot (`.`) if not set.

When it needs to set the new value, base on the key, it is using a dot instead Instead of using the separator key that was set before.

## Why
The parser does not use the defined `keySeparator` when `useKeysAsDefaultValue` set to `true`: 

`i18next-parser.config.js`
```
{
  useKeysAsDefaultValue: true,
  keySeparator: '_',
}
```
```
t('example.com')
```
Will parse as:
```
{
  "example": {
    "com": "example.com"
  }
}
```
Instead of:
```
{
  "example.com": "example.com"
}
```