### PR TITLE
Guard when plural rule is undefined

### DIFF
--- a/dist/transform.js
+++ b/dist/transform.js
@@ -159,19 +159,17 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
         };
 
         // generates plurals according to i18next rules: key, key_plural, key_0, key_1, etc.
-        var pluralRule = _i18next2.default.services.pluralResolver.getRule(locale);
-        if (pluralRule) {(function () {var
-            numbers = pluralRule.numbers;var _loop2 = function _loop2(
-            entry) {
-              if (entry.count !== undefined) {
-                numbers.forEach(function (_, i) {
-                  transformEntry(entry, getPluralSuffix(numbers, i));
-                });
-              } else {
-                transformEntry(entry);
-              }};var _iteratorNormalCompletion3 = true;var _didIteratorError3 = false;var _iteratorError3 = undefined;try {for (var _iterator3 = _this2.entries[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {var entry = _step3.value;_loop2(entry);
-              }} catch (err) {_didIteratorError3 = true;_iteratorError3 = err;} finally {try {if (!_iteratorNormalCompletion3 && _iterator3.return) {_iterator3.return();}} finally {if (_didIteratorError3) {throw _iteratorError3;}}}})();
-        }
+        var pluralRule = _i18next2.default.services.pluralResolver.getRule(locale);var _ref =
+        pluralRule || {},_ref$numbers = _ref.numbers,numbers = _ref$numbers === undefined ? [] : _ref$numbers;var _loop2 = function _loop2(
+        entry) {
+          if (entry.count !== undefined) {
+            numbers.forEach(function (_, i) {
+              transformEntry(entry, getPluralSuffix(numbers, i));
+            });
+          } else {
+            transformEntry(entry);
+          }};var _iteratorNormalCompletion3 = true;var _didIteratorError3 = false;var _iteratorError3 = undefined;try {for (var _iterator3 = _this2.entries[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {var entry = _step3.value;_loop2(entry);
+          }} catch (err) {_didIteratorError3 = true;_iteratorError3 = err;} finally {try {if (!_iteratorNormalCompletion3 && _iterator3.return) {_iterator3.return();}} finally {if (_didIteratorError3) {throw _iteratorError3;}}}
 
         var outputPath = _path2.default.resolve(_this2.options.output);
 

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -126,8 +126,7 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
       }var _loop = function _loop(
 
       locale) {
-        var catalog = {};var _i18next$services$plu =
-        _i18next2.default.services.pluralResolver.getRule(locale),numbers = _i18next$services$plu.numbers;
+        var catalog = {};
 
         var countWithPlurals = 0;
         var uniqueCount = _this2.entries.length;
@@ -160,15 +159,19 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
         };
 
         // generates plurals according to i18next rules: key, key_plural, key_0, key_1, etc.
-        var _loop2 = function _loop2(entry) {
-          if (entry.count !== undefined) {
-            numbers.forEach(function (_, i) {
-              transformEntry(entry, getPluralSuffix(numbers, i));
-            });
-          } else {
-            transformEntry(entry);
-          }};var _iteratorNormalCompletion3 = true;var _didIteratorError3 = false;var _iteratorError3 = undefined;try {for (var _iterator3 = _this2.entries[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {var entry = _step3.value;_loop2(entry);
-          }} catch (err) {_didIteratorError3 = true;_iteratorError3 = err;} finally {try {if (!_iteratorNormalCompletion3 && _iterator3.return) {_iterator3.return();}} finally {if (_didIteratorError3) {throw _iteratorError3;}}}
+        var pluralRule = _i18next2.default.services.pluralResolver.getRule(locale);
+        if (pluralRule) {(function () {var
+            numbers = pluralRule.numbers;var _loop2 = function _loop2(
+            entry) {
+              if (entry.count !== undefined) {
+                numbers.forEach(function (_, i) {
+                  transformEntry(entry, getPluralSuffix(numbers, i));
+                });
+              } else {
+                transformEntry(entry);
+              }};var _iteratorNormalCompletion3 = true;var _didIteratorError3 = false;var _iteratorError3 = undefined;try {for (var _iterator3 = _this2.entries[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {var entry = _step3.value;_loop2(entry);
+              }} catch (err) {_didIteratorError3 = true;_iteratorError3 = err;} finally {try {if (!_iteratorNormalCompletion3 && _iterator3.return) {_iterator3.return();}} finally {if (_didIteratorError3) {throw _iteratorError3;}}}})();
+        }
 
         var outputPath = _path2.default.resolve(_this2.options.output);
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -160,16 +160,14 @@ export default class i18nTransform extends Transform {
 
       // generates plurals according to i18next rules: key, key_plural, key_0, key_1, etc.
       const pluralRule = i18next.services.pluralResolver.getRule(locale);
-      if (pluralRule) {
-        const { numbers } = pluralRule;
-        for (const entry of this.entries) {
-          if (entry.count !== undefined) {
-            numbers.forEach((_, i) => {
-              transformEntry(entry, getPluralSuffix(numbers, i))
-            })
-          } else {
-            transformEntry(entry)
-          }
+      const { numbers = []} = pluralRule || {};
+      for (const entry of this.entries) {
+        if (entry.count !== undefined) {
+          numbers.forEach((_, i) => {
+            transformEntry(entry, getPluralSuffix(numbers, i))
+          })
+        } else {
+          transformEntry(entry)
         }
       }
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -127,7 +127,6 @@ export default class i18nTransform extends Transform {
 
     for (const locale of this.options.locales) {
       const catalog = {}
-      const { numbers } = i18next.services.pluralResolver.getRule(locale)
 
       let countWithPlurals = 0
       let uniqueCount = this.entries.length
@@ -160,13 +159,17 @@ export default class i18nTransform extends Transform {
       }
 
       // generates plurals according to i18next rules: key, key_plural, key_0, key_1, etc.
-      for (const entry of this.entries) {
-        if (entry.count !== undefined) {
-          numbers.forEach((_, i) => {
-            transformEntry(entry, getPluralSuffix(numbers, i))
-          })
-        } else {
-          transformEntry(entry)
+      const pluralRule = i18next.services.pluralResolver.getRule(locale);
+      if (pluralRule) {
+        const { numbers } = pluralRule;
+        for (const entry of this.entries) {
+          if (entry.count !== undefined) {
+            numbers.forEach((_, i) => {
+              transformEntry(entry, getPluralSuffix(numbers, i))
+            })
+          } else {
+            transformEntry(entry)
+          }
         }
       }
 


### PR DESCRIPTION
Sometimes (e.g. for `fr`) the plural rule seems to be undefined and it fails:

```
  [write] /Users/tstirrat/dev/x/app/locales/fr.json
gj
/Users/tstirrat/dev/i18next-parser/dist/transform.js:227
        }} catch (err) {_didIteratorError2 = true;_iteratorError2 = err;} finally {try {if (!_iteratorNormalCompletion2 && _iterator2.return) {_iterator2.return();}} finally {if (_didIteratorError2) {throw _iteratorError2;}}}
                                                                                                                                                                                                        ^

TypeError: Cannot read property 'numbers' of undefined
    at _loop (/Users/tstirrat/dev/i18next-parser/dist/transform.js:133:20)
    at i18nTransform._flush (/Users/tstirrat/dev/i18next-parser/dist/transform.js:226:318)
    at i18nTransform.prefinish (_stream_transform.js:142:10)
    at i18nTransform.emit (events.js:315:20)
    at prefinish (_stream_writable.js:640:14)
    at finishMaybe (_stream_writable.js:648:5)
    at endWritable (_stream_writable.js:670:3)
    at i18nTransform.Writable.end (_stream_writable.js:598:5)
    at DestroyableTransform.onend (/Users/tstirrat/dev/i18next-parser/node_modules/readable-stream/lib/_stream_readable.js:577:10)
    at Object.onceWrapper (events.js:421:28)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! privatekit@0.9.1 i18n:extract: `i18next`
npm ERR! Exit status 1
```

```
i18next@^19.3.3:
  version "19.3.4"
i18next-parser@^1.0.2:
  version "1.0.2"
```