### PR TITLE
Added ability to define value output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,8 @@ module.exports = {
   verbose: false,
   // Display info about the parsing including some stats
 
-  valueFormat: 'default',
-  // Default value format is key: value
-  // If you wish to output the value as an object, you can set your own format.
+  customValueTemplate: null,
+  // If you wish to customize the value output the value as an object, you can set your own format.
   // ${defaultValue} is the default value you set in your translation function.
   // Any other custom property will be automatically extracted.
   //

--- a/README.md
+++ b/README.md
@@ -187,6 +187,18 @@ module.exports = {
 
   verbose: false,
   // Display info about the parsing including some stats
+
+  valueFormat: 'default',
+  // Default value format is key: value
+  // If you wish to output the value as an object, you can set your own format.
+  // ${defaultValue} is the default value you set in your translation function.
+  // Any other custom property will be automatically extracted.
+  //
+  // Example:
+  // {
+  //   message: "${defaultValue}",
+  //   description: "${maxLength}", // t('my-key', {maxLength: 150})
+  // }
 }
 ```
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -64,7 +64,7 @@ function dotPathToHash(entry, target = {}, options = {}) {
         inner[lastSegment][valueEntry[0]] = newValue
       }
       else {
-        inner[lastSegment][valueEntry[0]] = entry[valueEntry[1].replace(/\${(\w+)}/, '$1')]
+        inner[lastSegment][valueEntry[0]] = entry[valueEntry[1].replace(/\${(\w+)}/, '$1')] || ""
       }
     })
   } else {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -54,7 +54,27 @@ function dotPathToHash(entry, target = {}, options = {}) {
     conflict = typeof oldValue !== typeof newValue ? 'key' : 'value';
   }
   const duplicate = oldValue !== undefined || conflict !== false
-  inner[lastSegment] = newValue
+
+  if (options.valueFormat && options.valueFormat !== 'default') {
+    inner[lastSegment] = {}
+
+    const getKeyByValue = (object, value) => {
+      return Object.keys(object).find(k => object[k] === value);
+    }
+
+    inner[lastSegment][getKeyByValue(options.valueFormat, '${defaultValue}')] = newValue
+
+    Object.values(options.valueFormat).forEach((extractedKey) => {
+      if (extractedKey === '${defaultValue}') {
+        return
+      }
+
+      inner[lastSegment][getKeyByValue(options.valueFormat, extractedKey)] = entry[extractedKey.replace(/\${(\w+)}/, '$1')]
+    })
+
+  } else {
+    inner[lastSegment] = newValue
+  }
 
   return { target, duplicate, conflict }
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -55,23 +55,18 @@ function dotPathToHash(entry, target = {}, options = {}) {
   }
   const duplicate = oldValue !== undefined || conflict !== false
 
-  if (options.valueFormat && options.valueFormat !== 'default') {
+  if (options.customValueTemplate) {
     inner[lastSegment] = {}
 
-    const getKeyByValue = (object, value) => {
-      return Object.keys(object).find(k => object[k] === value);
-    }
-
-    inner[lastSegment][getKeyByValue(options.valueFormat, '${defaultValue}')] = newValue
-
-    Object.values(options.valueFormat).forEach((extractedKey) => {
-      if (extractedKey === '${defaultValue}') {
-        return
+    const entries = Object.entries(options.customValueTemplate)
+    entries.forEach(valueEntry => {
+      if(valueEntry[1] === '${defaultValue}') {
+        inner[lastSegment][valueEntry[0]] = newValue
       }
-
-      inner[lastSegment][getKeyByValue(options.valueFormat, extractedKey)] = entry[extractedKey.replace(/\${(\w+)}/, '$1')]
+      else {
+        inner[lastSegment][valueEntry[0]] = entry[valueEntry[1].replace(/\${(\w+)}/, '$1')]
+      }
     })
-
   } else {
     inner[lastSegment] = newValue
   }

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -62,7 +62,6 @@ export default class JavascriptLexer extends BaseLexer {
         return null
       }
 
-
       const optionsArgument = node.arguments.shift()
 
       if (optionsArgument && optionsArgument.kind === ts.SyntaxKind.StringLiteral) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -40,7 +40,8 @@ export default class i18nTransform extends Transform {
       sort: false,
       useKeysAsDefaultValue: false,
       verbose: false,
-      skipDefaultValues: false
+      skipDefaultValues: false,
+      valueFormat: 'default'
     }
 
     this.options = { ...this.defaults, ...options }
@@ -143,6 +144,7 @@ export default class i18nTransform extends Transform {
             value: this.options.defaultValue,
             useKeysAsDefaultValue: this.options.useKeysAsDefaultValue,
             skipDefaultValues: this.options.skipDefaultValues,
+            valueFormat: this.options.valueFormat
           }
         )
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -41,7 +41,7 @@ export default class i18nTransform extends Transform {
       useKeysAsDefaultValue: false,
       verbose: false,
       skipDefaultValues: false,
-      valueFormat: 'default'
+      customValueTemplate: null
     }
 
     this.options = { ...this.defaults, ...options }
@@ -144,7 +144,7 @@ export default class i18nTransform extends Transform {
             value: this.options.defaultValue,
             useKeysAsDefaultValue: this.options.useKeysAsDefaultValue,
             skipDefaultValues: this.options.skipDefaultValues,
-            valueFormat: this.options.valueFormat
+            customValueTemplate: this.options.customValueTemplate
           }
         )
 

--- a/test/lexers/handlebars-lexer.test.js
+++ b/test/lexers/handlebars-lexer.test.js
@@ -58,6 +58,15 @@ describe('HandlebarsLexer', () => {
     done()
   })
 
+  it('ensure custom options are getting extracted', (done) => {
+    const Lexer = new HandlebarsLexer()
+    const content = '<p>{{t "first" description="bla"}}</p>'
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'first', description: 'bla' }
+    ])
+    done()
+  })
+
   describe('parseArguments()', () => {
     it('matches string arguments', (done) => {
       const Lexer = new HandlebarsLexer()

--- a/test/lexers/handlebars-lexer.test.js
+++ b/test/lexers/handlebars-lexer.test.js
@@ -58,7 +58,7 @@ describe('HandlebarsLexer', () => {
     done()
   })
 
-  it('ensure custom options are getting extracted', (done) => {
+  it('extracts custom options', (done) => {
     const Lexer = new HandlebarsLexer()
     const content = '<p>{{t "first" description="bla"}}</p>'
     assert.deepEqual(Lexer.extract(content), [

--- a/test/lexers/html-lexer.test.js
+++ b/test/lexers/html-lexer.test.js
@@ -78,4 +78,14 @@ describe('HTMLLexer', () => {
     ])
     done()
   })
+
+  it('ensure custom options are getting extracted', (done) => {
+    const Lexer = new HTMLLexer()
+    const content =
+      '<p data-i18n="first" data-i18n-options=\'{"description": "bla"}\'>first</p>'
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'first', description: 'bla' }
+    ])
+    done()
+  })
 })

--- a/test/lexers/html-lexer.test.js
+++ b/test/lexers/html-lexer.test.js
@@ -79,7 +79,7 @@ describe('HTMLLexer', () => {
     done()
   })
 
-  it('ensure custom options are getting extracted', (done) => {
+  it('extracts custom options', (done) => {
     const Lexer = new HTMLLexer()
     const content =
       '<p data-i18n="first" data-i18n-options=\'{"description": "bla"}\'>first</p>'

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -136,7 +136,7 @@ describe('JavascriptLexer', () => {
     assert.deepEqual(Lexer.extract(content), [{ namespace: 'baz', key: 'bar', ns: 'baz' }])
   })
 
-  it('ensure custom options are getting extracted', () => {
+  it('extracts custom options', () => {
     const Lexer = new JavascriptLexer()
 
     const content = 'i18n.t("headline", {description: "Fantastic key!"});'

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -136,4 +136,13 @@ describe('JavascriptLexer', () => {
     assert.deepEqual(Lexer.extract(content), [{ namespace: 'baz', key: 'bar', ns: 'baz' }])
   })
 
+  it('ensure custom options are getting extracted', () => {
+    const Lexer = new JavascriptLexer()
+
+    const content = 'i18n.t("headline", {description: "Fantastic key!"});'
+    assert.deepEqual(Lexer.extract(content), [{
+      key: 'headline',
+      description: 'Fantastic key!'
+    }])
+  })
 })

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -127,6 +127,19 @@ describe('JsxLexer', () => {
       done()
     })
 
+    it('ensure custom options are getting extracted', (done) => {
+      const Lexer = new JsxLexer({
+        valueFormat: {
+          message: '${defaultValue}',
+          description: '${max}'
+        }
+      })
+      const content = '<Trans max="wow">Yo</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'Yo', defaultValue: 'Yo', max: 'wow' }
+      ])
+      done()
+    })
   })
 
   describe('supports TypeScript', () => {

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -18,8 +18,9 @@ describe('JsxLexer', () => {
     it('extracts keys from i18nKey attributes from closing tags', (done) => {
       const Lexer = new JsxLexer()
       const content = '<Trans i18nKey="first" count={count}>Yo</Trans>'
+      console.log(Lexer.extract(content))
       assert.deepEqual(Lexer.extract(content), [
-        { key: 'first', defaultValue: 'Yo' }
+        { key: 'first', defaultValue: 'Yo', count: '{count}' }
       ])
       done()
     })
@@ -28,7 +29,7 @@ describe('JsxLexer', () => {
       const Lexer = new JsxLexer({ attr: "myIntlKey" })
       const content = '<Trans myIntlKey="first" count={count}>Yo</Trans>'
       assert.deepEqual(Lexer.extract(content), [
-        { key: 'first', defaultValue: 'Yo' }
+        { key: 'first', defaultValue: 'Yo', count: '{count}' }
       ])
       done()
     })
@@ -37,7 +38,7 @@ describe('JsxLexer', () => {
       const Lexer = new JsxLexer()
       const content = '<Trans i18nKey="first" count={count} />'
       assert.deepEqual(Lexer.extract(content), [
-        { key: 'first' }
+        { key: 'first', count: '{count}' }
       ])
       done()
     })
@@ -46,16 +47,25 @@ describe('JsxLexer', () => {
       const Lexer = new JsxLexer({ attr: "myIntlKey" })
       const content = '<Trans myIntlKey="first" count={count} />'
       assert.deepEqual(Lexer.extract(content), [
-        { key: 'first' }
+        { key: 'first', count: '{count}' }
       ])
       done()
     })
 
+    it('extracts custom attributes', (done) => {
+      const Lexer = new JsxLexer()
+      const content = '<Trans customAttribute="Youpi">Yo</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'Yo', defaultValue: 'Yo', customAttribute: 'Youpi' }
+      ])
+      done()
+    })
+    
     it('extracts keys from Trans elements without an i18nKey', (done) => {
       const Lexer = new JsxLexer()
       const content = '<Trans count={count}>Yo</Trans>'
       assert.deepEqual(Lexer.extract(content), [
-        { key: 'Yo', defaultValue: 'Yo' }
+        { key: 'Yo', defaultValue: 'Yo', count: '{count}' }
       ])
       done()
     })
@@ -64,7 +74,7 @@ describe('JsxLexer', () => {
       const Lexer = new JsxLexer()
       const content = '<Trans count={count}>{{ key: property }}</Trans>'
       assert.deepEqual(Lexer.extract(content), [
-        { key: '{{key}}', defaultValue: '{{key}}' }
+        { key: '{{key}}', defaultValue: '{{key}}', count: '{count}' }
       ])
       done()
     })
@@ -73,7 +83,7 @@ describe('JsxLexer', () => {
       const Lexer = new JsxLexer()
       const content = '<Trans count={count}>before{{ key1, key2 }}after</Trans>'
       assert.deepEqual(Lexer.extract(content), [
-        { key: 'beforeafter', defaultValue: 'beforeafter' }
+        { key: 'beforeafter', defaultValue: 'beforeafter', count: '{count}' }
       ])
       done()
     })
@@ -126,20 +136,6 @@ describe('JsxLexer', () => {
       assert.deepEqual(Lexer.extract(content), [{ key: 'bar', defaultValue: 'bar', namespace: 'foo' }])
       done()
     })
-
-    it('ensure custom options are getting extracted', (done) => {
-      const Lexer = new JsxLexer({
-        valueFormat: {
-          message: '${defaultValue}',
-          description: '${max}'
-        }
-      })
-      const content = '<Trans max="wow">Yo</Trans>'
-      assert.deepEqual(Lexer.extract(content), [
-        { key: 'Yo', defaultValue: 'Yo', max: 'wow' }
-      ])
-      done()
-    })
   })
 
   describe('supports TypeScript', () => {
@@ -167,7 +163,7 @@ describe('JsxLexer', () => {
         const Lexer = new JsxLexer()
         const content = '<Trans i18nKey="first" count={count}>Yo</Trans>'
         assert.deepEqual(Lexer.extract(content), [
-          { key: 'first', defaultValue: 'Yo' }
+          { key: 'first', defaultValue: 'Yo', count: '{count}' }
         ])
         done()
       })
@@ -176,7 +172,7 @@ describe('JsxLexer', () => {
         const Lexer = new JsxLexer({ attr: "myIntlKey" })
         const content = '<Trans myIntlKey="first" count={count}>Yo</Trans>'
         assert.deepEqual(Lexer.extract(content), [
-          { key: 'first', defaultValue: 'Yo' }
+          { key: 'first', defaultValue: 'Yo', count: '{count}' }
         ])
         done()
       })
@@ -185,7 +181,7 @@ describe('JsxLexer', () => {
         const Lexer = new JsxLexer()
         const content = '<Trans i18nKey="first" count={count} />'
         assert.deepEqual(Lexer.extract(content), [
-          { key: 'first' }
+          { key: 'first', count: '{count}' }
         ])
         done()
       })
@@ -194,7 +190,7 @@ describe('JsxLexer', () => {
         const Lexer = new JsxLexer({ attr: "myIntlKey" })
         const content = '<Trans myIntlKey="first" count={count} />'
         assert.deepEqual(Lexer.extract(content), [
-          { key: 'first' }
+          { key: 'first', count: '{count}' }
         ])
         done()
       })
@@ -203,7 +199,7 @@ describe('JsxLexer', () => {
         const Lexer = new JsxLexer()
         const content = '<Trans count={count}>Yo</Trans>'
         assert.deepEqual(Lexer.extract(content), [
-          { key: 'Yo', defaultValue: 'Yo' }
+          { key: 'Yo', defaultValue: 'Yo', count: '{count}' }
         ])
         done()
       })
@@ -212,7 +208,7 @@ describe('JsxLexer', () => {
         const Lexer = new JsxLexer()
         const content = '<Trans count={count}>{{ key: property }}</Trans>'
         assert.deepEqual(Lexer.extract(content), [
-          { key: '{{key}}', defaultValue: '{{key}}' }
+          { key: '{{key}}', defaultValue: '{{key}}', count: '{count}' }
         ])
         done()
       })
@@ -221,7 +217,7 @@ describe('JsxLexer', () => {
         const Lexer = new JsxLexer()
         const content = '<Trans count={count}>before{{ key1, key2 }}after</Trans>'
         assert.deepEqual(Lexer.extract(content), [
-          { key: 'beforeafter', defaultValue: 'beforeafter' }
+          { key: 'beforeafter', defaultValue: 'beforeafter', count: '{count}' }
         ])
         done()
       })

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -18,7 +18,6 @@ describe('JsxLexer', () => {
     it('extracts keys from i18nKey attributes from closing tags', (done) => {
       const Lexer = new JsxLexer()
       const content = '<Trans i18nKey="first" count={count}>Yo</Trans>'
-      console.log(Lexer.extract(content))
       assert.deepEqual(Lexer.extract(content), [
         { key: 'first', defaultValue: 'Yo', count: '{count}' }
       ])

--- a/test/lexers/vue-lexer.test.js
+++ b/test/lexers/vue-lexer.test.js
@@ -7,7 +7,7 @@ describe('VueLexer', () => {
     const content =
       "<template><p>{{ $t('first') }}</p><template><script>export default " +
       "{ mounted() { this.$i18n.t('second'); } }</script>"
-    assert.deepEqual(Lexer.extract(content), [{ key: 'second' },{ key: 'first' }])
+    assert.deepEqual(Lexer.extract(content), [{ key: 'second' }, { key: 'first' }])
     done()
   })
 
@@ -39,6 +39,15 @@ describe('VueLexer', () => {
       key: 'first',
       count: '5'
     }])
+    done()
+  })
+
+  it('ensure custom options are getting extracted', (done) => {
+    const Lexer = new VueLexer()
+    const content =
+      "<template><p>{{ $t('first', {description: 'test'}) }}</p><template><script>export default " +
+      "{ mounted() { this.$i18n.t('second'); } }</script>"
+    assert.deepEqual(Lexer.extract(content), [{ key: 'second' }, { key: 'first', description: 'test' }])
     done()
   })
 })

--- a/test/lexers/vue-lexer.test.js
+++ b/test/lexers/vue-lexer.test.js
@@ -42,7 +42,7 @@ describe('VueLexer', () => {
     done()
   })
 
-  it('ensure custom options are getting extracted', (done) => {
+  it('extracts custom options', (done) => {
     const Lexer = new VueLexer()
     const content =
       "<template><p>{{ $t('first', {description: 'test'}) }}</p><template><script>export default " +

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -181,11 +181,13 @@ describe('parser', () => {
       second: '',
       third: {
         first: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.',
+        first_plural: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.',
         second: ' <1>Hello,</1> this shouldn\'t be trimmed.',
         third: '<0>Hello,</0>this should be trimmed.<2> and this shoudln\'t</2>'
       },
       fourth: '',
       fifth: '',
+      fifth_plural: '',
       bar: '',
       foo: '',
       "This should be part of the value and the key": "This should be part of the value and the key",
@@ -220,11 +222,13 @@ describe('parser', () => {
       second: '',
       third: {
         first: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.',
+        first_plural: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.',
         second: ' <1>Hello,</1> this shouldn\'t be trimmed.',
         third: '<0>Hello,</0>this should be trimmed.<2> and this shoudln\'t</2>'
       },
       fourth: '',
       fifth: '',
+      fifth_plural: '',
       bar: '',
       foo: '',
       "This should be part of the value and the key": "This should be part of the value and the key",
@@ -699,11 +703,13 @@ describe('parser', () => {
         second: '',
         third: {
           first: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.',
+          first_plural: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.',
           second: ' <1>Hello,</1> this shouldn\'t be trimmed.',
           third: '<0>Hello,</0>this should be trimmed.<2> and this shoudln\'t</2>'
         },
         fourth: '',
         fifth: '',
+        fifth_plural: '',
         bar: '',
         foo: '',
         "This should be part of the value and the key": "This should be part of the value and the key",
@@ -748,11 +754,13 @@ describe('parser', () => {
         second: '',
         third: {
           first: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.',
+          first_plural: 'Hello <1>{{name}}</1>, you have {{count}} unread message. <5>Go to messages</5>.',
           second: ' <b>Hello,</b> this shouldn\'t be trimmed.',
           third: '<b>Hello,</b>this should be trimmed.<2> and this shoudln\'t</2>'
         },
         fourth: '',
         fifth: '',
+        fifth_plural: '',
         bar: '',
         foo: '',
         "This should be part of the value and the key": "This should be part of the value and the key",
@@ -1051,7 +1059,7 @@ describe('parser', () => {
     it('custom JSON output', (done) => {
       let result
       const i18nextParser = new i18nTransform({
-        valueFormat: {
+        customValueTemplate: {
           message: '${defaultValue}'
         }
       })
@@ -1085,7 +1093,7 @@ describe('parser', () => {
       let result
       const i18nextParser = new i18nTransform({
         output: 'locales/$LOCALE/$NAMESPACE.yml',
-        valueFormat: {
+        customValueTemplate: {
           message: '${defaultValue}'
         }
       })
@@ -1110,7 +1118,7 @@ describe('parser', () => {
     it('extract custom options', (done) => {
       let result
       const i18nextParser = new i18nTransform({
-        valueFormat: {
+        customValueTemplate: {
           message: '${defaultValue}',
           description: '${max}'
         }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1048,6 +1048,97 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     });
 
+    it('custom JSON output', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({
+        valueFormat: {
+          message: '${defaultValue}'
+        }
+      })
+
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('test'); t('salt', 'salty'}"),
+        path: 'file.js'
+      })
+
+      i18nextParser.on('data', file => {
+        result = JSON.parse(file.contents)
+      })
+
+      i18nextParser.once('end', () => {
+        assert.deepEqual(result, {
+          'test': {
+            'message': ''
+          },
+          'salt': {
+            'message': 'salty'
+          }
+        })
+
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
+    it('custom yml output', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({
+        output: 'locales/$LOCALE/$NAMESPACE.yml',
+        valueFormat: {
+          message: '${defaultValue}'
+        }
+      })
+
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('test'); t('salt', 'salty'}"),
+        path: 'file.js'
+      })
+
+      i18nextParser.on('data', file => {
+        result = file.contents.toString('utf8')
+      })
+
+      i18nextParser.once('end', () => {
+        assert.equal(result.replace(/\r\n/g, '\n'), 'test:\n  message: ""\nsalt:\n  message: salty\n')
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
+    it('extract custom options', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({
+        valueFormat: {
+          message: '${defaultValue}',
+          description: '${max}'
+        }
+      })
+
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('test', {max: 150}"),
+        path: 'file.js'
+      })
+
+      i18nextParser.on('data', file => {
+        result = JSON.parse(file.contents)
+      })
+
+      i18nextParser.once('end', () => {
+        assert.deepEqual(result, {
+          'test': {
+            'message': '',
+            'description': '150'
+          }
+        })
+
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     describe('lexers', () => {
       it('support custom lexers options', (done) => {
         let result

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1056,66 +1056,8 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     });
 
-    it('custom JSON output', (done) => {
-      let result
-      const i18nextParser = new i18nTransform({
-        customValueTemplate: {
-          message: '${defaultValue}'
-        }
-      })
-
-      const fakeFile = new Vinyl({
-        contents: Buffer.from("t('test'); t('salt', 'salty'}"),
-        path: 'file.js'
-      })
-
-      i18nextParser.on('data', file => {
-        result = JSON.parse(file.contents)
-      })
-
-      i18nextParser.once('end', () => {
-        assert.deepEqual(result, {
-          'test': {
-            'message': ''
-          },
-          'salt': {
-            'message': 'salty'
-          }
-        })
-
-        done()
-      })
-
-      i18nextParser.end(fakeFile)
-    })
-
-    it('custom yml output', (done) => {
-      let result
-      const i18nextParser = new i18nTransform({
-        output: 'locales/$LOCALE/$NAMESPACE.yml',
-        customValueTemplate: {
-          message: '${defaultValue}'
-        }
-      })
-
-      const fakeFile = new Vinyl({
-        contents: Buffer.from("t('test'); t('salt', 'salty'}"),
-        path: 'file.js'
-      })
-
-      i18nextParser.on('data', file => {
-        result = file.contents.toString('utf8')
-      })
-
-      i18nextParser.once('end', () => {
-        assert.equal(result.replace(/\r\n/g, '\n'), 'test:\n  message: ""\nsalt:\n  message: salty\n')
-        done()
-      })
-
-      i18nextParser.end(fakeFile)
-    })
-
-    it('extract custom options', (done) => {
+    
+    it('supports customValueTemplate option', (done) => {
       let result
       const i18nextParser = new i18nTransform({
         customValueTemplate: {
@@ -1125,7 +1067,7 @@ describe('parser', () => {
       })
 
       const fakeFile = new Vinyl({
-        contents: Buffer.from("t('test', {max: 150}"),
+        contents: Buffer.from("t('test'); t('salt', {defaultValue: 'salty', max: 150})"),
         path: 'file.js'
       })
 
@@ -1137,6 +1079,10 @@ describe('parser', () => {
         assert.deepEqual(result, {
           'test': {
             'message': '',
+            'description': ''
+          },
+          'salt': {
+            'message': 'salty',
             'description': '150'
           }
         })


### PR DESCRIPTION
closes #211

- added new option called "valueFormat"
- default behaviour: {key: value}
- alternatively you can define your own value format
- parser will automatically extract the properties you need

- tests:
  - tested that all parsers can extract custom props
  - exception: jsx parser wasn't doing it by default
  - tested for JSON + yml format