### PR TITLE
Add support for multiline template literals

### DIFF
--- a/dist/lexers/javascript-lexer.js
+++ b/dist/lexers/javascript-lexer.js
@@ -47,12 +47,16 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
       if (isTranslationFunction) {
         var keyArgument = node.arguments.shift();
 
-        if (keyArgument && keyArgument.kind === ts.SyntaxKind.StringLiteral) {
-          entry.key = keyArgument.text;
-        } else if (
-        keyArgument &&
-        keyArgument.kind === ts.SyntaxKind.BinaryExpression)
+        if (!keyArgument) {
+          return null;
+        }
+
+        if (
+        keyArgument.kind === ts.SyntaxKind.StringLiteral ||
+        keyArgument.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral)
         {
+          entry.key = keyArgument.text;
+        } else if (keyArgument.kind === ts.SyntaxKind.BinaryExpression) {
           var concatenatedString = this.concatenateString(keyArgument);
           if (!concatenatedString) {
             this.emit(
@@ -69,7 +73,6 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
             keyArgument.text);
 
           }
-
           return null;
         }
 

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -47,12 +47,16 @@ export default class JavascriptLexer extends BaseLexer {
     if (isTranslationFunction) {
       const keyArgument = node.arguments.shift()
 
-      if (keyArgument && keyArgument.kind === ts.SyntaxKind.StringLiteral) {
-        entry.key = keyArgument.text
-      } else if (
-        keyArgument &&
-        keyArgument.kind === ts.SyntaxKind.BinaryExpression
+      if (!keyArgument) {
+        return null
+      }
+
+      if (
+        keyArgument.kind === ts.SyntaxKind.StringLiteral ||
+        keyArgument.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral
       ) {
+        entry.key = keyArgument.text
+      } else if (keyArgument.kind === ts.SyntaxKind.BinaryExpression) {
         const concatenatedString = this.concatenateString(keyArgument)
         if (!concatenatedString) {
           this.emit(
@@ -69,7 +73,6 @@ export default class JavascriptLexer extends BaseLexer {
             `Key is not a string literal: ${keyArgument.text}`
           )
         }
-
         return null
       }
 

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -64,6 +64,13 @@ describe('JavascriptLexer', () => {
     done()
   })
 
+  it('supports multiline template literal keys', (done) => {
+    const Lexer = new JavascriptLexer()
+    const content = 'i18n.t(`foo\nbar`)'
+    assert.deepEqual(Lexer.extract(content), [{ key: 'foo\nbar' }])
+    done()
+  })
+
   it("does not parse text with `doesn't` or isolated `t` in it", (done) => {
     const Lexer = new JavascriptLexer()
     const js =


### PR DESCRIPTION
Fixes: #83 

Adds supports for multiline template literals that have no interpolated expressions, e.g.:

```
t(`multi
line);
```
will result in `"multi\nline"` which is consistent with `react-i18next`.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added