### PR TITLE
Extract translations from comments

### DIFF
--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -75,6 +75,7 @@ describe('JavascriptLexer', () => {
     const Lexer = new JavascriptLexer()
     const content = `
     // i18n.t('commentKey1')
+    i18n.t('commentKey' + i)
     // i18n.t('commentKey2')
     i18n.t(\`commentKey\${i}\`)
     // Irrelevant comment

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -71,6 +71,42 @@ describe('JavascriptLexer', () => {
     done()
   })
 
+  it('extracts keys from single line comments', (done) => {
+    const Lexer = new JavascriptLexer()
+    const content = `
+    // i18n.t('commentKey1')
+    // i18n.t('commentKey2')
+    i18n.t(\`commentKey\${i}\`)
+    // Irrelevant comment
+    // i18n.t('commentKey3')
+    `
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'commentKey1' },
+      { key: 'commentKey2' },
+      { key: 'commentKey3' },
+    ])
+    done()
+  })
+
+  it('extracts keys from multiline comments', (done) => {
+    const Lexer = new JavascriptLexer()
+    const content = `
+    /*
+      i18n.t('commentKey1')
+      i18n.t('commentKey2')
+    */
+    i18n.t(\`commentKey\${i}\`)
+    // Irrelevant comment
+    /* i18n.t('commentKey3') */
+    `
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'commentKey1' },
+      { key: 'commentKey2' },
+      { key: 'commentKey3' },
+    ])
+    done()
+  })
+
   it("does not parse text with `doesn't` or isolated `t` in it", (done) => {
     const Lexer = new JavascriptLexer()
     const js =


### PR DESCRIPTION
Adds support for extracting translations from comments. Relevant for: #83 #215

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added