### PR TITLE
Accept a function for the defaultValue, useKeysAsDefaultValue, and skipDefaultValues configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ module.exports = {
 
   defaultValue: '',
   // Default value to give to empty keys
+  // You may also specify a function accepting the locale, namespace, and key as arguments
 
   indentation: 2,
   // Indentation of the catalog files
@@ -178,11 +179,13 @@ module.exports = {
   // Whether or not to sort the catalog
 
   skipDefaultValues: false,
-  // Whether to ignore default values.
+  // Whether to ignore default values
+  // You may also specify a function accepting the locale and namespace as arguments
 
   useKeysAsDefaultValue: false,
   // Whether to use the keys as the default value; ex. "Hello": "Hello", "World": "World"
   // This option takes precedence over the `defaultValue` and `skipDefaultValues` options
+  // You may also specify a function accepting the locale and namespace as arguments
 
   verbose: false,
   // Display info about the parsing including some stats

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -11,24 +11,39 @@
                                                                                                                                                                                                                                                                                                                                                       * {one: {two: "bla"}}), `"value"` if the same key already exists swith a
                                                                                                                                                                                                                                                                                                                                                       * different value, or `false`.
                                                                                                                                                                                                                                                                                                                                                       */
-function dotPathToHash(entry) {var target = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+function dotPathToHash(locale, entry) {var target = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
   var path = entry.key;
   if (options.suffix || options.suffix === 0) {
     path += '_' + options.suffix;
   }
 
   var separator = options.separator || '.';
-  var newValue = entry.defaultValue || options.value || '';
+  var key = entry.key.substring(
+  entry.key.indexOf(separator) + separator.length,
+  entry.key.length);
 
-  if (options.skipDefaultValues) {
+  var useKeysAsDefaultValue =
+  typeof options.useKeysAsDefaultValue === 'function' ?
+  options.useKeysAsDefaultValue(locale, entry.namespace) :
+  options.useKeysAsDefaultValue;
+  var skipDefaultValues =
+  typeof options.skipDefaultValues === 'function' ?
+  options.skipDefaultValues(locale, entry.namespace) :
+  options.skipDefaultValues;
+  var defaultValue =
+  typeof options.value === 'function' ?
+  options.value(locale, entry.namespace, key) :
+  options.value;
+
+  var newValue = void 0;
+  if (useKeysAsDefaultValue) {
+    newValue = key;
+  } else if (skipDefaultValues) {
     newValue = '';
-  }
-
-  if (options.useKeysAsDefaultValue) {
-    newValue = entry.key.substring(
-    entry.key.indexOf(separator) + separator.length,
-    entry.key.length);
-
+  } else if (entry.defaultValue) {
+    newValue = entry.defaultValue;
+  } else {
+    newValue = defaultValue || '';
   }
 
   if (path.endsWith(separator)) {

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -11,7 +11,7 @@
                                                                                                                                                                                                                                                                                                                                                       * {one: {two: "bla"}}), `"value"` if the same key already exists swith a
                                                                                                                                                                                                                                                                                                                                                       * different value, or `false`.
                                                                                                                                                                                                                                                                                                                                                       */
-function dotPathToHash(locale, entry) {var target = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+function dotPathToHash(entry) {var target = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
   var path = entry.key;
   if (options.suffix || options.suffix === 0) {
     path += '_' + options.suffix;
@@ -24,15 +24,15 @@ function dotPathToHash(locale, entry) {var target = arguments.length > 2 && argu
 
   var useKeysAsDefaultValue =
   typeof options.useKeysAsDefaultValue === 'function' ?
-  options.useKeysAsDefaultValue(locale, entry.namespace) :
+  options.useKeysAsDefaultValue(options.locale, entry.namespace) :
   options.useKeysAsDefaultValue;
   var skipDefaultValues =
   typeof options.skipDefaultValues === 'function' ?
-  options.skipDefaultValues(locale, entry.namespace) :
+  options.skipDefaultValues(options.locale, entry.namespace) :
   options.skipDefaultValues;
   var defaultValue =
   typeof options.value === 'function' ?
-  options.value(locale, entry.namespace, key) :
+  options.value(options.locale, entry.namespace, key) :
   options.value;
 
   var newValue = void 0;

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -133,8 +133,9 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
         var uniqueCount = _this2.entries.length;
 
         var transformEntry = function transformEntry(entry, suffix) {var _dotPathToHash =
-          (0, _helpers.dotPathToHash)(locale, entry, catalog, {
+          (0, _helpers.dotPathToHash)(entry, catalog, {
             suffix: suffix,
+            locale: locale,
             separator: _this2.options.keySeparator,
             value: _this2.options.defaultValue,
             useKeysAsDefaultValue: _this2.options.useKeysAsDefaultValue,

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -133,7 +133,7 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
         var uniqueCount = _this2.entries.length;
 
         var transformEntry = function transformEntry(entry, suffix) {var _dotPathToHash =
-          (0, _helpers.dotPathToHash)(entry, catalog, {
+          (0, _helpers.dotPathToHash)(locale, entry, catalog, {
             suffix: suffix,
             separator: _this2.options.keySeparator,
             value: _this2.options.defaultValue,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,7 +11,7 @@
  * {one: {two: "bla"}}), `"value"` if the same key already exists swith a
  * different value, or `false`.
  */
-function dotPathToHash(locale, entry, target = {}, options = {}) {
+function dotPathToHash(entry, target = {}, options = {}) {
   let path = entry.key
   if (options.suffix || options.suffix === 0) {
     path += `_${options.suffix}`
@@ -24,15 +24,15 @@ function dotPathToHash(locale, entry, target = {}, options = {}) {
   )
   const useKeysAsDefaultValue =
     typeof options.useKeysAsDefaultValue === 'function'
-      ? options.useKeysAsDefaultValue(locale, entry.namespace)
+      ? options.useKeysAsDefaultValue(options.locale, entry.namespace)
       : options.useKeysAsDefaultValue
   const skipDefaultValues =
     typeof options.skipDefaultValues === 'function'
-      ? options.skipDefaultValues(locale, entry.namespace)
+      ? options.skipDefaultValues(options.locale, entry.namespace)
       : options.skipDefaultValues
   const defaultValue =
     typeof options.value === 'function'
-      ? options.value(locale, entry.namespace, key)
+      ? options.value(options.locale, entry.namespace, key)
       : options.value
 
   let newValue

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,24 +11,39 @@
  * {one: {two: "bla"}}), `"value"` if the same key already exists swith a
  * different value, or `false`.
  */
-function dotPathToHash(entry, target = {}, options = {}) {
+function dotPathToHash(locale, entry, target = {}, options = {}) {
   let path = entry.key
   if (options.suffix || options.suffix === 0) {
     path += `_${options.suffix}`
   }
 
   const separator = options.separator || '.'
-  let newValue = entry.defaultValue || options.value || ''
+  const key = entry.key.substring(
+    entry.key.indexOf(separator) + separator.length,
+    entry.key.length
+  )
+  const useKeysAsDefaultValue =
+    typeof options.useKeysAsDefaultValue === 'function'
+      ? options.useKeysAsDefaultValue(locale, entry.namespace)
+      : options.useKeysAsDefaultValue
+  const skipDefaultValues =
+    typeof options.skipDefaultValues === 'function'
+      ? options.skipDefaultValues(locale, entry.namespace)
+      : options.skipDefaultValues
+  const defaultValue =
+    typeof options.value === 'function'
+      ? options.value(locale, entry.namespace, key)
+      : options.value
 
-  if (options.skipDefaultValues) {
+  let newValue
+  if (useKeysAsDefaultValue) {
+    newValue = key
+  } else if (skipDefaultValues) {
     newValue = ''
-  }
-
-  if (options.useKeysAsDefaultValue) {
-    newValue = entry.key.substring(
-      entry.key.indexOf(separator) + separator.length,
-      entry.key.length
-    )
+  } else if (entry.defaultValue) {
+    newValue = entry.defaultValue
+  } else {
+    newValue = defaultValue || ''
   }
 
   if (path.endsWith(separator)) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -133,8 +133,9 @@ export default class i18nTransform extends Transform {
       let uniqueCount = this.entries.length
 
       const transformEntry = (entry, suffix) => {
-        const { duplicate, conflict } = dotPathToHash(locale, entry, catalog, {
+        const { duplicate, conflict } = dotPathToHash(entry, catalog, {
           suffix,
+          locale,
           separator: this.options.keySeparator,
           value: this.options.defaultValue,
           useKeysAsDefaultValue: this.options.useKeysAsDefaultValue,

--- a/src/transform.js
+++ b/src/transform.js
@@ -133,7 +133,7 @@ export default class i18nTransform extends Transform {
       let uniqueCount = this.entries.length
 
       const transformEntry = (entry, suffix) => {
-        const { duplicate, conflict } = dotPathToHash(entry, catalog, {
+        const { duplicate, conflict } = dotPathToHash(locale, entry, catalog, {
           suffix,
           separator: this.options.keySeparator,
           value: this.options.defaultValue,

--- a/test/helpers/dotPathToHash.test.js
+++ b/test/helpers/dotPathToHash.test.js
@@ -3,32 +3,43 @@ import { dotPathToHash } from '../../src/helpers'
 
 describe('dotPathToHash helper function', () => {
   it('creates an object from a string path', (done) => {
-    const { target, duplicate } = dotPathToHash({ key: 'one' })
+    const { target, duplicate } = dotPathToHash('en', { key: 'one' })
     assert.deepEqual(target, { one: '' })
     assert.equal(duplicate, false)
     done()
   })
 
   it('ignores trailing separator', (done) => {
-    const { target } = dotPathToHash({ key: 'one.' }, {}, { separator: '.' })
+    const { target } = dotPathToHash(
+      'en',
+      { key: 'one.' },
+      {},
+      { separator: '.' }
+    )
     assert.deepEqual(target, { one: '' })
     done()
   })
 
   it('ignores duplicated separator', (done) => {
-    const { target } = dotPathToHash({ key: 'one..two' })
+    const { target } = dotPathToHash('en', { key: 'one..two' })
     assert.deepEqual(target, { one: { two: '' } })
     done()
   })
 
   it('supports custom separator', (done) => {
-    const { target } = dotPathToHash({ key: 'one-two' }, {}, { separator: '-' })
+    const { target } = dotPathToHash(
+      'en',
+      { key: 'one-two' },
+      {},
+      { separator: '-' }
+    )
     assert.deepEqual(target, { one: { two: '' } })
     done()
   })
 
   it('supports custom separator when `useKeysAsDefaultValue` is true', (done) => {
     const { target } = dotPathToHash(
+      'en',
       { key: 'namespace-two-three' },
       {},
       { separator: '-', useKeysAsDefaultValue: true }
@@ -39,6 +50,7 @@ describe('dotPathToHash helper function', () => {
 
   it('handles a target hash', (done) => {
     const { target, duplicate } = dotPathToHash(
+      'en',
       { key: 'one.two.three' },
       { one: { twenty: '' } }
     )
@@ -49,6 +61,7 @@ describe('dotPathToHash helper function', () => {
 
   it('handles a `defaultValue` option', (done) => {
     const { target } = dotPathToHash(
+      'en',
       { key: 'one' },
       {},
       { value: 'myDefaultValue' }
@@ -59,6 +72,7 @@ describe('dotPathToHash helper function', () => {
 
   it('handles a `separator` option', (done) => {
     const { target } = dotPathToHash(
+      'en',
       { key: 'one_two_three.' },
       {},
       { separator: '_' }
@@ -69,6 +83,7 @@ describe('dotPathToHash helper function', () => {
 
   it('detects duplicate keys with the same value', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
+      'en',
       { key: 'one.two.three' },
       { one: { two: { three: '' } } }
     )
@@ -80,6 +95,7 @@ describe('dotPathToHash helper function', () => {
 
   it('detects and overwrites duplicate keys with different values', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
+      'en',
       { key: 'one.two.three', defaultValue: 'new' },
       { one: { two: { three: 'old' } } }
     )
@@ -91,6 +107,7 @@ describe('dotPathToHash helper function', () => {
 
   it('overwrites keys already mapped to a string with an object value', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
+      'en',
       { key: 'one', defaultValue: 'bla' },
       { one: { two: { three: 'bla' } } }
     )
@@ -102,6 +119,7 @@ describe('dotPathToHash helper function', () => {
 
   it('overwrites keys already mapped to an object with a string value', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
+      'en',
       { key: 'one.two.three', defaultValue: 'bla' },
       { one: 'bla' }
     )

--- a/test/helpers/dotPathToHash.test.js
+++ b/test/helpers/dotPathToHash.test.js
@@ -3,43 +3,32 @@ import { dotPathToHash } from '../../src/helpers'
 
 describe('dotPathToHash helper function', () => {
   it('creates an object from a string path', (done) => {
-    const { target, duplicate } = dotPathToHash('en', { key: 'one' })
+    const { target, duplicate } = dotPathToHash({ key: 'one' })
     assert.deepEqual(target, { one: '' })
     assert.equal(duplicate, false)
     done()
   })
 
   it('ignores trailing separator', (done) => {
-    const { target } = dotPathToHash(
-      'en',
-      { key: 'one.' },
-      {},
-      { separator: '.' }
-    )
+    const { target } = dotPathToHash({ key: 'one.' }, {}, { separator: '.' })
     assert.deepEqual(target, { one: '' })
     done()
   })
 
   it('ignores duplicated separator', (done) => {
-    const { target } = dotPathToHash('en', { key: 'one..two' })
+    const { target } = dotPathToHash({ key: 'one..two' })
     assert.deepEqual(target, { one: { two: '' } })
     done()
   })
 
   it('supports custom separator', (done) => {
-    const { target } = dotPathToHash(
-      'en',
-      { key: 'one-two' },
-      {},
-      { separator: '-' }
-    )
+    const { target } = dotPathToHash({ key: 'one-two' }, {}, { separator: '-' })
     assert.deepEqual(target, { one: { two: '' } })
     done()
   })
 
   it('supports custom separator when `useKeysAsDefaultValue` is true', (done) => {
     const { target } = dotPathToHash(
-      'en',
       { key: 'namespace-two-three' },
       {},
       { separator: '-', useKeysAsDefaultValue: true }
@@ -50,7 +39,6 @@ describe('dotPathToHash helper function', () => {
 
   it('handles a target hash', (done) => {
     const { target, duplicate } = dotPathToHash(
-      'en',
       { key: 'one.two.three' },
       { one: { twenty: '' } }
     )
@@ -61,7 +49,6 @@ describe('dotPathToHash helper function', () => {
 
   it('handles a `defaultValue` option', (done) => {
     const { target } = dotPathToHash(
-      'en',
       { key: 'one' },
       {},
       { value: 'myDefaultValue' }
@@ -72,7 +59,6 @@ describe('dotPathToHash helper function', () => {
 
   it('handles a `separator` option', (done) => {
     const { target } = dotPathToHash(
-      'en',
       { key: 'one_two_three.' },
       {},
       { separator: '_' }
@@ -83,7 +69,6 @@ describe('dotPathToHash helper function', () => {
 
   it('detects duplicate keys with the same value', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
-      'en',
       { key: 'one.two.three' },
       { one: { two: { three: '' } } }
     )
@@ -95,7 +80,6 @@ describe('dotPathToHash helper function', () => {
 
   it('detects and overwrites duplicate keys with different values', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
-      'en',
       { key: 'one.two.three', defaultValue: 'new' },
       { one: { two: { three: 'old' } } }
     )
@@ -107,7 +91,6 @@ describe('dotPathToHash helper function', () => {
 
   it('overwrites keys already mapped to a string with an object value', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
-      'en',
       { key: 'one', defaultValue: 'bla' },
       { one: { two: { three: 'bla' } } }
     )
@@ -119,7 +102,6 @@ describe('dotPathToHash helper function', () => {
 
   it('overwrites keys already mapped to an object with a string value', (done) => {
     const { target, duplicate, conflict } = dotPathToHash(
-      'en',
       { key: 'one.two.three', defaultValue: 'bla' },
       { one: 'bla' }
     )

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -666,6 +666,86 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    it('supports a defaultValue function', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({
+        defaultValue: (locale, namespace, key) =>
+          `${locale}:${namespace}:${key}`,
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('first')"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(enLibraryPath)) {
+          result = JSON.parse(file.contents)
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.deepEqual(result, { first: 'en:translation:first' })
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
+    it('supports a useKeysAsDefaultValue function', (done) => {
+      let enResult
+      let arResult
+      const i18nextParser = new i18nTransform({
+        locales: ['en', 'ar'],
+        useKeysAsDefaultValue: (locale, namespace) => locale === 'en',
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('first')"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(enLibraryPath)) {
+          enResult = JSON.parse(file.contents)
+        } else if (file.relative.endsWith(arLibraryPath)) {
+          arResult = JSON.parse(file.contents)
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.deepEqual(enResult, { first: 'first' })
+        assert.deepEqual(arResult, { first: '' })
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
+    it('supports a skipDefaultValues function', (done) => {
+      let enResult
+      let arResult
+      const i18nextParser = new i18nTransform({
+        locales: ['en', 'ar'],
+        skipDefaultValues: (locale, namespace) => locale === 'en',
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('first', { defaultValue: 'default' })"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(enLibraryPath)) {
+          enResult = JSON.parse(file.contents)
+        } else if (file.relative.endsWith(arLibraryPath)) {
+          arResult = JSON.parse(file.contents)
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.deepEqual(enResult, { first: '' })
+        assert.deepEqual(arResult, { first: 'default' })
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     it('supports a lineEnding', (done) => {
       let result
       const i18nextParser = new i18nTransform({


### PR DESCRIPTION
### Why am I submitting this PR

There are a few scenarios in which it would be helpful to be able to define a function for these configuration options. For example, you may want to generate a default value for the `en` locale, but not for other locales. Also, if you are using natural language keys, `useKeysAsDefaultValue` doesn't do exactly the right thing because it will include the `_{context}` within the default value. Specifying a function for the `defaultValue` makes it possible to remove the context if you wish to do so.

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
