### PR TITLE
Add transUseDefaultValueFromOptions JsxLexer option

### DIFF
--- a/dist/lexers/jsx-lexer.js
+++ b/dist/lexers/jsx-lexer.js
@@ -11,8 +11,10 @@ JsxLexer = function (_JavascriptLexer) {_inherits(JsxLexer, _JavascriptLexer);
     'br',
     'strong',
     'i',
-    'p'];return _this;
+    'p'];
 
+    _this.transUseDefaultValueFromOptions =
+    options.transUseDefaultValueFromOptions || false;return _this;
   }_createClass(JsxLexer, [{ key: 'extract', value: function extract(
 
     content) {var _this2 = this;var filename = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '__default.jsx';
@@ -69,10 +71,12 @@ JsxLexer = function (_JavascriptLexer) {_inherits(JsxLexer, _JavascriptLexer);
         var defaultValue = this.nodeToString.call(this, node, sourceText);
 
         if (defaultValue !== '') {
-          entry.defaultValue = defaultValue;
+          if (!this.transUseDefaultValueFromOptions) {
+            entry.defaultValue = defaultValue;
+          }
 
           if (!entry.key) {
-            entry.key = entry.defaultValue;
+            entry.key = defaultValue;
           }
         }
 

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -13,6 +13,8 @@ export default class JsxLexer extends JavascriptLexer {
       'i',
       'p',
     ]
+    this.transUseDefaultValueFromOptions =
+      options.transUseDefaultValueFromOptions || false
   }
 
   extract(content, filename = '__default.jsx') {
@@ -69,10 +71,12 @@ export default class JsxLexer extends JavascriptLexer {
       const defaultValue = this.nodeToString.call(this, node, sourceText)
 
       if (defaultValue !== '') {
-        entry.defaultValue = defaultValue
+        if (!this.transUseDefaultValueFromOptions) {
+          entry.defaultValue = defaultValue
+        }
 
         if (!entry.key) {
-          entry.key = entry.defaultValue
+          entry.key = defaultValue
         }
       }
 

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -252,6 +252,13 @@ describe('JsxLexer', () => {
         assert.equal(Lexer.extract(content)[0].defaultValue, 'Some Content')
         done()
       })
+
+      it('refrains from setting the defaultValue if transUseDefaultValueFromOptions is true', (done) => {
+        const Lexer = new JsxLexer({ transUseDefaultValueFromOptions: true })
+        const content = '<Trans>Some Content</Trans>'
+        assert.isUndefined(Lexer.extract(content)[0].defaultValue)
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
### Why am I submitting this PR

Because `entry.defaultValue` takes precedence over `options.defaultValue`, it currently isn't possible to specify a default value in the options for \<Trans\> components. #207 tried to solve this but it doesn't seem like a consensus was established about the approach. This PR takes a different approach: add a lexer option to JsxLexer that simply turns off setting the default value on the entry. The existing behavior is unchanged when this option is not included.

### Does it fix an existing ticket?

Yes: #206

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
