### PR TITLE
fix: Trans element usage with curly braces syntax

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -61,7 +61,12 @@ export default class JsxLexer extends JavascriptLexer {
       const attribute = node.attributes.properties.find(
         (attr) => attr.name.text === tagName
       )
-      return attribute && attribute.initializer.text
+      if (!attribute) {
+        return undefined
+      }
+      return attribute.initializer.expression
+        ? attribute.initializer.expression.text
+        : attribute.initializer.text
     }
 
     const getKey = (node) => getPropValue(node, this.attr)

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -176,6 +176,15 @@ describe('JsxLexer', () => {
       ])
       done()
     })
+
+    it('uses the ns (namespace) prop with curly braces syntax', (done) => {
+      const Lexer = new JsxLexer()
+      const content = `<Trans ns={'foo'}>bar</Trans>`
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'bar', defaultValue: 'bar', namespace: 'foo' },
+      ])
+      done()
+    })
   })
 
   describe('supports TypeScript', () => {


### PR DESCRIPTION
### Why am I submitting this PR

If the namespace is provided in curly-braces, it will fall back to the default namespace.
```
<Trans ns={'foo'}>bar</Trans>
```

To avoid this, I added a fix for it and as well a test-case for the curly braces syntax.

### Does it fix an existing ticket?

No
