### PR TITLE
Correct regexp to extract namespace from withTranslation HOC

### DIFF
--- a/dist/transform.js
+++ b/dist/transform.js
@@ -299,7 +299,7 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
 
     content) {
       var reactTranslateRegex = new RegExp(
-      'translate\\((?:\\s*\\[?\\s*)(' + _baseLexer2.default.stringPattern + ')');
+      'withTranslation\\((?:\\s*\\[?\\s*)(' + _baseLexer2.default.stringPattern + ')');
 
       var translateMatches = content.match(reactTranslateRegex);
       if (translateMatches) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -299,7 +299,7 @@ export default class i18nTransform extends Transform {
 
   grabReactNamespace(content) {
     const reactTranslateRegex = new RegExp(
-      'translate\\((?:\\s*\\[?\\s*)(' + BaseLexer.stringPattern + ')'
+      'withTranslation\\((?:\\s*\\[?\\s*)(' + BaseLexer.stringPattern + ')'
     )
     const translateMatches = content.match(reactTranslateRegex)
     if (translateMatches) {

--- a/test/templating/react.jsx
+++ b/test/templating/react.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { translate, Trans, Interpolate } from 'react-i18next'
+import { withTranslation, Trans, Interpolate } from 'react-i18next'
 
 const bar = () => (
   <div>
@@ -42,4 +42,4 @@ class Test extends React.Component {
   }
 }
 
-export default translate('react')(Test)
+export default withTranslation('react')(Test)


### PR DESCRIPTION
### Why am I submitting this PR

Looks like regexp is outdated using old react-i18next HOC name

### Does it fix an existing ticket?

No

### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
