### PR TITLE
Remove react namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,6 @@ module.exports = {
   // An array of globs that describe where to look for source files
   // relative to the location of the configuration file
 
-  reactNamespace: false,
-  // For react file, extract the defaultNamespace - https://react.i18next.com/latest/withtranslation-hoc
-  // Ignored when parsing a `.jsx` file and namespace is extracted from that file.
-
   sort: false,
   // Whether or not to sort the catalog
 
@@ -221,7 +217,6 @@ The default configuration is below:
   js: [{
     lexer: 'JavascriptLexer'
     functions: ['t'], // Array of functions to match
-
   }],
 }
 ```
@@ -239,6 +234,16 @@ Default configuration:
   jsx: [{
     lexer: 'JsxLexer',
     attr: 'i18nKey', // Attribute for the keys
+  }],
+}
+```
+
+If your JSX files have `.js` extension you should override the default `js` lexer with `JsxLexer` to enable jsx parsing from js files:
+
+```js
+{
+  js: [{
+    lexer: 'JsxLexer'
   }],
 }
 ```

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Default configuration:
 }
 ```
 
-If your JSX files have `.js` extension you should override the default `js` lexer with `JsxLexer` to enable jsx parsing from js files:
+If your JSX files have `.js` extension (e.g. create-react-app projects) you should override the default `js` lexer with `JsxLexer` to enable jsx parsing from js files:
 
 ```js
 {

--- a/dist/parser.js
+++ b/dist/parser.js
@@ -36,11 +36,6 @@ Parser = function (_EventEmitter) {_inherits(Parser, _EventEmitter);
   function Parser() {var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};_classCallCheck(this, Parser);var _this = _possibleConstructorReturn(this, (Parser.__proto__ || Object.getPrototypeOf(Parser)).call(this,
     options));
     _this.options = options;
-
-    if (options.reactNamespace) {
-      lexers.js = lexers.jsx;
-    }
-
     _this.lexers = _extends({}, lexers, options.lexers);return _this;
   }_createClass(Parser, [{ key: 'parse', value: function parse(
 

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -35,7 +35,6 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
       locales: ['en', 'fr'],
       namespaceSeparator: ':',
       output: 'locales/$LOCALE/$NAMESPACE.json',
-      reactNamespace: false,
       sort: false,
       useKeysAsDefaultValue: false,
       verbose: false,

--- a/src/parser.js
+++ b/src/parser.js
@@ -36,11 +36,6 @@ export default class Parser extends EventEmitter {
   constructor(options = {}) {
     super(options)
     this.options = options
-
-    if (options.reactNamespace) {
-      lexers.js = lexers.jsx
-    }
-
     this.lexers = { ...lexers, ...options.lexers }
   }
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -35,7 +35,6 @@ export default class i18nTransform extends Transform {
       locales: ['en', 'fr'],
       namespaceSeparator: ':',
       output: 'locales/$LOCALE/$NAMESPACE.json',
-      reactNamespace: false,
       sort: false,
       useKeysAsDefaultValue: false,
       verbose: false,

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -766,10 +766,16 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
-    it('parses Trans if reactNamespace is true', (done) => {
+    it('parses Trans from js file with lexer override to JsxLexer', (done) => {
       let result
       const i18nextParser = new i18nTransform({
-        reactNamespace: true,
+        lexers: {
+          js: [
+            {
+              lexer: 'JsxLexer',
+            },
+          ],
+        },
       })
       const fakeFile = new Vinyl({
         contents: fs.readFileSync(
@@ -1438,7 +1444,7 @@ describe('parser', () => {
       })
       const fakeFile = new Vinyl({
         contents: Buffer.from('<Trans>{{ key1, key2 }}</Trans>'),
-        path: 'file.js',
+        path: 'file.jsx',
       })
 
       i18nextParser.on('warning', (message) => {


### PR DESCRIPTION
Removed `reactNamespace` and documented alternative way to get the same functionality the flag was providing - interpreting js files as jsx files (e.g. create-react-app projects).

# Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
