### PR TITLE
Improve Warnings in CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ npm-debug.log
 
 # project files
 .idea/
+
+# manual test files
+test/manual/en
+test/manual/fr

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Multiple globbing patterns are supported to specify complex file selections. You
 - **-c, --config <path>**: Path to the config file (default: i18next-parser.config.js).
 - **-o, --output <path>**: Path to the output directory (default: locales/$LOCALE/$NAMESPACE.json).
 - **-S, --silent**: Disable logging to stdout.
+- **--fail-on-warnings**: Exit with an exit code of 1 on warnings
 
 ### Gulp
 
@@ -186,6 +187,9 @@ module.exports = {
 
   verbose: false,
   // Display info about the parsing including some stats
+
+  failOnWarnings: false,
+  // Exit with an exit code of 1 on warnings
 
   customValueTemplate: null
   // If you wish to customize the value output the value as an object, you can set your own format.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,6 +14,7 @@ program
 .option('-c, --config <path>', 'Path to the config file (default: i18next-parser.config.js)', 'i18next-parser.config.js')
 .option('-o, --output <path>', 'Path to the output directory (default: locales/$LOCALE/$NAMESPACE.json)')
 .option('-s, --silent', 'Disable logging to stdout')
+.option('--fail-on-warnings', 'Exit with an exit code of 1 on warnings')
 
 program.on('--help', function() {
   console.log('  Examples:')
@@ -39,6 +40,7 @@ try {
 }
 
 config.output = program.output || config.output || 'locales/$LOCALE/$NAMESPACE.json'
+config.failOnWarnings = program.failOnWarnings || config.failOnWarnings || false
 
 var args = program.args || []
 var globs
@@ -85,10 +87,10 @@ if (!globs.length) {
 
 // Welcome message
 console.log()
-console.log('  i18next Parser'.yellow)
-console.log('  --------------'.yellow)
-console.log('  Input:  '.yellow + args.join(', '))
-console.log('  Output: '.yellow + config.output)
+console.log('  i18next Parser'.blue)
+console.log('  --------------'.blue)
+console.log('  Input:  '.blue + args.join(', '))
+console.log('  Output: '.blue + config.output)
 if (!program.silent) {
   console.log()
 }
@@ -117,11 +119,16 @@ vfs.src(globs)
     }
     console.log('  [error] '.red + message)
   })
+  .on('warning', function (message) {
+    if (!program.silent) {
+      console.log('  [warning] '.yellow + message)
+    }
+  })
   .on('finish', function () {
     if (!program.silent) {
       console.log()
     }
-    console.log('  Stats:  '.yellow + count + ' files were parsed')
+    console.log('  Stats:  '.blue + count + ' files were parsed')
   })
 )
 .pipe(vfs.dest(process.cwd()))

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -40,7 +40,8 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
       useKeysAsDefaultValue: false,
       verbose: false,
       skipDefaultValues: false,
-      customValueTemplate: null };
+      customValueTemplate: null,
+      failOnWarnings: false };
 
 
     _this.options = _extends({}, _this.defaults, options);
@@ -52,6 +53,7 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
     }
     _this.entries = [];
 
+    _this.parserHadWarnings = false;
     _this.parser = new _parser2.default(_this.options);
     _this.parser.on('error', function (error) {return _this.error(error);});
     _this.parser.on('warning', function (warning) {return _this.warn(warning);});
@@ -71,6 +73,7 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
 
     warning) {
       this.emit('warning', warning);
+      this.parserHadWarnings = true;
       if (this.options.verbose) {
         console.warn('\x1b[33m%s\x1b[0m', warning);
       }
@@ -218,6 +221,10 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
             console.log();
           }
 
+          if (_this2.options.failOnWarnings && _this2.parserHadWarnings) {
+            continue;
+          }
+
           // push files back to the stream
           _this2.pushFile(namespacePath, newCatalog);
           if (
@@ -228,6 +235,12 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
           }
         }};var _iteratorNormalCompletion2 = true;var _didIteratorError2 = false;var _iteratorError2 = undefined;try {for (var _iterator2 = this.options.locales[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {var locale = _step2.value;_loop(locale);
         }} catch (err) {_didIteratorError2 = true;_iteratorError2 = err;} finally {try {if (!_iteratorNormalCompletion2 && _iterator2.return) {_iterator2.return();}} finally {if (_didIteratorError2) {throw _iteratorError2;}}}
+
+      if (this.options.failOnWarnings && this.parserHadWarnings) {
+        console.log();
+        console.log('  Saw warnings with failOnWarnings set. Exiting.'.red);
+        process.exit(1);
+      }
 
       done();
     } }, { key: 'addEntry', value: function addEntry(

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,7 +43,8 @@ To test the CLI:
 ```
 yarn link
 cd test
-i18next test/**/*.html  -c i18next-parser.config.js
+i18next manual/**/*.html  -c i18next-parser.config.js
+i18next manual/**/*.html  -c i18next-parser.config.js --fail-on-warnings
 ```
 
 To test gulp:

--- a/src/transform.js
+++ b/src/transform.js
@@ -41,6 +41,7 @@ export default class i18nTransform extends Transform {
       verbose: false,
       skipDefaultValues: false,
       customValueTemplate: null,
+      failOnWarnings: false,
     }
 
     this.options = { ...this.defaults, ...options }
@@ -52,6 +53,7 @@ export default class i18nTransform extends Transform {
     }
     this.entries = []
 
+    this.parserHadWarnings = false
     this.parser = new Parser(this.options)
     this.parser.on('error', (error) => this.error(error))
     this.parser.on('warning', (warning) => this.warn(warning))
@@ -71,6 +73,7 @@ export default class i18nTransform extends Transform {
 
   warn(warning) {
     this.emit('warning', warning)
+    this.parserHadWarnings = true
     if (this.options.verbose) {
       console.warn('\x1b[33m%s\x1b[0m', warning)
     }
@@ -218,6 +221,10 @@ export default class i18nTransform extends Transform {
           console.log()
         }
 
+        if (this.options.failOnWarnings && this.parserHadWarnings) {
+          continue
+        }
+
         // push files back to the stream
         this.pushFile(namespacePath, newCatalog)
         if (
@@ -227,6 +234,12 @@ export default class i18nTransform extends Transform {
           this.pushFile(namespaceOldPath, oldCatalog)
         }
       }
+    }
+
+    if (this.options.failOnWarnings && this.parserHadWarnings) {
+      console.log()
+      console.log('  Saw warnings with failOnWarnings set. Exiting.'.red)
+      process.exit(1)
     }
 
     done()

--- a/test/manual/html.html
+++ b/test/manual/html.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="description" data-i18n="selfClosing" content="content"/>
+  <meta name="keywords" content="some keywords"/>
+  <meta name="google-site-verification" content="google-key"/>
+  <meta name="yandex-verification" content="yandex-key"/>
+  <title>Lorem ipsum dolor sit amet, consectetur adipiscing elit</title>
+</head>
+
+<body id="main">
+  <div class="foobar">
+    <p data-i18n="first">First</p>
+    <p title="second" data-i18n>second</p>
+    <p data-i18n="[title]third;fourth">Fourth</p>
+    <p
+      title=""
+      bla
+      data-i18n="fifth"
+      data-i18n-options='{"defaultValue": "bar"}'
+    ></p>
+    <p
+      title=""
+      bla
+      data-i18n="sixth"
+    >asd</p>
+    <p data-i18n="seventh" data-i18n-options='{"defaultValue": "foo"}'>Seventh</p>
+    <p data-i18n="seventh" data-i18n-options='{"defaultValue": "bar"}'>Seventh</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### Why am I submitting this PR

Warnings are currently invisible outside of verbose mode. These are a nice feature, and it would be helpful for users to see these. We also use i18next-parser as part of automated build processes, and having the translation catalog build fail on a warning would be useful in that process.

This PR
- Changes status text in the CLI to blue
- Displays warnings in yellow by default
- Adds a `--fail-on-warnings` flag to exit with a an exit code of 1 on warnings
- Adds a `--suppress-warnings` flag to restore the original behavior

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
