### PR TITLE
Parse default value from 'defaults' prop in Trans

### DIFF
--- a/dist/lexers/jsx-lexer.js
+++ b/dist/lexers/jsx-lexer.js
@@ -11,8 +11,9 @@ JsxLexer = function (_JavascriptLexer) {_inherits(JsxLexer, _JavascriptLexer);
     'br',
     'strong',
     'i',
-    'p'];return _this;
+    'p'];
 
+    _this.omitAttributes = [_this.attr, 'ns', 'defaults'];return _this;
   }_createClass(JsxLexer, [{ key: 'extract', value: function extract(
 
     content) {var _this2 = this;var filename = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '__default.jsx';
@@ -75,7 +76,9 @@ JsxLexer = function (_JavascriptLexer) {_inherits(JsxLexer, _JavascriptLexer);
         var entry = {};
         entry.key = getKey(tagNode);
 
-        var defaultValue = this.nodeToString.call(this, node, sourceText);
+        var defaultsProp = getPropValue(tagNode, 'defaults');
+        var defaultValue =
+        defaultsProp || this.nodeToString.call(this, node, sourceText);
 
         if (defaultValue !== '') {
           entry.defaultValue = defaultValue;
@@ -91,7 +94,7 @@ JsxLexer = function (_JavascriptLexer) {_inherits(JsxLexer, _JavascriptLexer);
         }
 
         tagNode.attributes.properties.forEach(function (property) {
-          if ([_this3.attr, 'ns'].includes(property.name.text)) {
+          if (_this3.omitAttributes.includes(property.name.text)) {
             return;
           }
 

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -13,6 +13,7 @@ export default class JsxLexer extends JavascriptLexer {
       'i',
       'p',
     ]
+    this.omitAttributes = [this.attr, 'ns', 'defaults']
   }
 
   extract(content, filename = '__default.jsx') {
@@ -75,7 +76,9 @@ export default class JsxLexer extends JavascriptLexer {
       const entry = {}
       entry.key = getKey(tagNode)
 
-      const defaultValue = this.nodeToString.call(this, node, sourceText)
+      const defaultsProp = getPropValue(tagNode, 'defaults')
+      const defaultValue =
+        defaultsProp || this.nodeToString.call(this, node, sourceText)
 
       if (defaultValue !== '') {
         entry.defaultValue = defaultValue
@@ -91,7 +94,7 @@ export default class JsxLexer extends JavascriptLexer {
       }
 
       tagNode.attributes.properties.forEach((property) => {
-        if ([this.attr, 'ns'].includes(property.name.text)) {
+        if (this.omitAttributes.includes(property.name.text)) {
           return
         }
 

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -21,6 +21,26 @@ describe('JsxLexer', () => {
       done()
     })
 
+    it('extracts default value from string literal `defaults` prop', (done) => {
+      const Lexer = new JsxLexer()
+      const content =
+        '<Trans i18nKey="first" defaults="test-value">should be ignored</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'first', defaultValue: 'test-value' },
+      ])
+      done()
+    })
+
+    it('extracts default value from interpolated expression statement `defaults` prop', (done) => {
+      const Lexer = new JsxLexer()
+      const content =
+        '<Trans i18nKey="first" defaults={"test-value"}>should be ignored</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'first', defaultValue: 'test-value' },
+      ])
+      done()
+    })
+
     it('extracts keys from user-defined key attributes from closing tags', (done) => {
       const Lexer = new JsxLexer({ attr: 'myIntlKey' })
       const content = '<Trans myIntlKey="first" count={count}>Yo</Trans>'

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -193,6 +193,7 @@ describe('parser', () => {
       'This should be part of the value and the key':
         'This should be part of the value and the key',
       "don't split {{on}}": "don't split {{on}}",
+      'override-default': 'default override',
     }
 
     i18nextParser.on('data', (file) => {
@@ -803,6 +804,7 @@ describe('parser', () => {
         'This should be part of the value and the key':
           'This should be part of the value and the key',
         "don't split {{on}}": "don't split {{on}}",
+        'override-default': 'default override',
       }
 
       i18nextParser.on('data', (file) => {
@@ -858,6 +860,7 @@ describe('parser', () => {
         'This should be part of the value and the key':
           'This should be part of the value and the key',
         "don't split {{on}}": "don't split {{on}}",
+        'override-default': 'default override',
       }
 
       i18nextParser.on('data', (file) => {

--- a/test/templating/react.jsx
+++ b/test/templating/react.jsx
@@ -38,6 +38,7 @@ class Test extends React.Component {
         <Trans>
           don't split {{ on: this }}
         </Trans>
+        <Trans i18nKey="override-default" defaults="default override">ignore me</Trans>
       </div>
     )
   }


### PR DESCRIPTION
Adds support for `defaults` prop in trans as per https://react.i18next.com/latest/trans-component#alternative-usage-v-11-6-0

Fixes: #231 & #206 

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
