### PR TITLE
Add plural forms for defaultValue

### DIFF
--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -18,7 +18,11 @@ function dotPathToHash(entry) {var target = arguments.length > 1 && arguments[1]
   }
 
   var separator = options.separator || '.';
-  var newValue = entry.defaultValue || options.value || '';
+  var newValue =
+  entry['defaultValue_' + options.suffix] ||
+  entry.defaultValue ||
+  options.value ||
+  '';
 
   if (options.skipDefaultValues) {
     newValue = '';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,7 +18,11 @@ function dotPathToHash(entry, target = {}, options = {}) {
   }
 
   const separator = options.separator || '.'
-  let newValue = entry.defaultValue || options.value || ''
+  let newValue =
+    entry[`defaultValue_${options.suffix}`] ||
+    entry.defaultValue ||
+    options.value ||
+    ''
 
   if (options.skipDefaultValues) {
     newValue = ''


### PR DESCRIPTION
Fixes #212 

Played around with plurals to determine correct fallbacks here: https://codesandbox.io/s/react-i18next-forked-58lpq

In i18next, `defaultValue_plural` alone wont' work, `defaultValue` is necessary, as it's used as a fallback for any missing plural forms.

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
