### PR TITLE
Extract options as third parameter when second parameter is default value string

### DIFF
--- a/dist/lexers/javascript-lexer.js
+++ b/dist/lexers/javascript-lexer.js
@@ -139,12 +139,16 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
 
         var optionsArgument = node.arguments.shift();
 
+        // Second argument could be a string default value
         if (
         optionsArgument &&
         optionsArgument.kind === ts.SyntaxKind.StringLiteral)
         {
           entry.defaultValue = optionsArgument.text;
-        } else if (
+          optionsArgument = node.arguments.shift();
+        }
+
+        if (
         optionsArgument &&
         optionsArgument.kind === ts.SyntaxKind.ObjectLiteralExpression)
         {var _iteratorNormalCompletion = true;var _didIteratorError = false;var _iteratorError = undefined;try {

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -137,14 +137,18 @@ export default class JavascriptLexer extends BaseLexer {
         return null
       }
 
-      const optionsArgument = node.arguments.shift()
+      let optionsArgument = node.arguments.shift()
 
+      // Second argument could be a string default value
       if (
         optionsArgument &&
         optionsArgument.kind === ts.SyntaxKind.StringLiteral
       ) {
         entry.defaultValue = optionsArgument.text
-      } else if (
+        optionsArgument = node.arguments.shift()
+      }
+
+      if (
         optionsArgument &&
         optionsArgument.kind === ts.SyntaxKind.ObjectLiteralExpression
       ) {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1117,6 +1117,30 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    it('generates plurals for defaultValue as second parameter', (done) => {
+      let result
+      const i18nextParser = new i18nTransform()
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('key', 'test {{count}}', { count })"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(enLibraryPath)) {
+          result = JSON.parse(file.contents)
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.deepEqual(result, {
+          key: 'test {{count}}',
+          key_plural: 'test {{count}}',
+        })
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     it('generates plurals for different defaultValue in singular and plural form', (done) => {
       let result
       const i18nextParser = new i18nTransform()
@@ -1143,7 +1167,7 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
-    it('generates plurals for different defaultValue in singular plural forms with fallback', (done) => {
+    it('generates plurals for different defaultValue in plural forms with fallback', (done) => {
       let result
       const i18nextParser = new i18nTransform({
         locales: ['ar'],


### PR DESCRIPTION
Fixes: #241

Options were not being parsed from the third parameter when second parameter was default value:  `t('key', 'test {{count}}', { count })`

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
