### PR TITLE
Add a 'component' option to JSX-lexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Default configuration:
   jsx: [{
     lexer: 'JsxLexer',
     attr: 'i18nKey', // Attribute for the keys
+    component: 'Trans', // Component name
   }],
 }
 ```

--- a/dist/lexers/jsx-lexer.js
+++ b/dist/lexers/jsx-lexer.js
@@ -13,7 +13,8 @@ JsxLexer = function (_JavascriptLexer) {_inherits(JsxLexer, _JavascriptLexer);
     'i',
     'p'];
 
-    _this.omitAttributes = [_this.attr, 'ns', 'defaults'];return _this;
+    _this.omitAttributes = [_this.attr, 'ns', 'defaults'];
+    _this.component = options.component || 'Trans';return _this;
   }_createClass(JsxLexer, [{ key: 'extract', value: function extract(
 
     content) {var _this2 = this;var filename = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '__default.jsx';
@@ -72,7 +73,7 @@ JsxLexer = function (_JavascriptLexer) {_inherits(JsxLexer, _JavascriptLexer);
 
       var getKey = function getKey(node) {return getPropValue(node, _this3.attr);};
 
-      if (tagNode.tagName.text === 'Trans') {
+      if (tagNode.tagName.text === this.component) {
         var entry = {};
         entry.key = getKey(tagNode);
 

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -14,6 +14,7 @@ export default class JsxLexer extends JavascriptLexer {
       'p',
     ]
     this.omitAttributes = [this.attr, 'ns', 'defaults']
+    this.component = options.component || 'Trans'
   }
 
   extract(content, filename = '__default.jsx') {
@@ -72,7 +73,7 @@ export default class JsxLexer extends JavascriptLexer {
 
     const getKey = (node) => getPropValue(node, this.attr)
 
-    if (tagNode.tagName.text === 'Trans') {
+    if (tagNode.tagName.text === this.component) {
       const entry = {}
       entry.key = getKey(tagNode)
 


### PR DESCRIPTION
### Why am I submitting this PR

Now you have a possibility to set a translation component name (default `Trans`).
User case: 
We've create a custom component for titles where passed the translation namespace and key `<ScreenTitle path="namespace:translationKey" />` as a result the parser always removes translated string from en.json files because it doesn't understand variables. After my changes I can set component to `ScreenTitle` and attr to `path` and parser works well.
The content of ScreenTitle:
```
export const ScreenTitle = ({ path }: Props) => {
    const { t } = useTranslation(getNameSpace(path));
    return <Text style={Style.headerTitleText}>{t(path)}</Text>;
};
```
### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added

