### PR TITLE
Improve YAML output

### DIFF
--- a/dist/transform.js
+++ b/dist/transform.js
@@ -5,7 +5,7 @@ var _fs = require('fs');var _fs2 = _interopRequireDefault(_fs);
 var _parser = require('./parser');var _parser2 = _interopRequireDefault(_parser);
 var _path = require('path');var _path2 = _interopRequireDefault(_path);
 var _vinyl = require('vinyl');var _vinyl2 = _interopRequireDefault(_vinyl);
-var _yamljs = require('yamljs');var _yamljs2 = _interopRequireDefault(_yamljs);
+var _jsYaml = require('js-yaml');var _jsYaml2 = _interopRequireDefault(_jsYaml);
 var _i18next = require('i18next');var _i18next2 = _interopRequireDefault(_i18next);function _interopRequireDefault(obj) {return obj && obj.__esModule ? obj : { default: obj };}function _classCallCheck(instance, Constructor) {if (!(instance instanceof Constructor)) {throw new TypeError("Cannot call a class as a function");}}function _possibleConstructorReturn(self, call) {if (!self) {throw new ReferenceError("this hasn't been initialised - super() hasn't been called");}return call && (typeof call === "object" || typeof call === "function") ? call : self;}function _inherits(subClass, superClass) {if (typeof superClass !== "function" && superClass !== null) {throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);}subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } });if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;}
 
 function getPluralSuffix(numberOfPluralForms, nthForm) {
@@ -264,7 +264,7 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
       try {
         var content = void 0;
         if (path.endsWith('yml')) {
-          content = _yamljs2.default.parse(_fs2.default.readFileSync(path).toString());
+          content = _jsYaml2.default.safeLoad(_fs2.default.readFileSync(path).toString());
         } else {
           content = JSON.parse(_fs2.default.readFileSync(path));
         }
@@ -281,7 +281,9 @@ i18nTransform = function (_Transform) {_inherits(i18nTransform, _Transform);
     path, contents) {
       var text = void 0;
       if (path.endsWith('yml')) {
-        text = _yamljs2.default.stringify(contents, null, this.options.indentation);
+        text = _jsYaml2.default.safeDump(contents, {
+          indent: this.options.indentation });
+
       } else {
         text = JSON.stringify(contents, null, this.options.indentation) + '\n';
       }

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "fs-extra": "^6.0.1",
     "gulp-sort": "^2.0.0",
     "i18next": "^19.0.1",
+    "js-yaml": "^3.14.0",
     "rsvp": "^4.8.2",
     "through2": "~2.0.3",
     "typescript": "^3.6.4",
     "vinyl": "~2.0.1",
     "vinyl-fs": "^3.0.2",
-    "vue-template-compiler": "^2.6.11",
-    "yamljs": "^0.3.0"
+    "vue-template-compiler": "^2.6.11"
   },
   "optionalDependencies": {},
   "engines": {

--- a/src/transform.js
+++ b/src/transform.js
@@ -5,7 +5,7 @@ import fs from 'fs'
 import Parser from './parser'
 import path from 'path'
 import VirtualFile from 'vinyl'
-import YAML from 'yamljs'
+import yaml from 'js-yaml'
 import i18next from 'i18next'
 
 function getPluralSuffix(numberOfPluralForms, nthForm) {
@@ -264,7 +264,7 @@ export default class i18nTransform extends Transform {
     try {
       let content
       if (path.endsWith('yml')) {
-        content = YAML.parse(fs.readFileSync(path).toString())
+        content = yaml.safeLoad(fs.readFileSync(path).toString())
       } else {
         content = JSON.parse(fs.readFileSync(path))
       }
@@ -281,7 +281,9 @@ export default class i18nTransform extends Transform {
   pushFile(path, contents) {
     let text
     if (path.endsWith('yml')) {
-      text = YAML.stringify(contents, null, this.options.indentation)
+      text = yaml.safeDump(contents, {
+        indent: this.options.indentation,
+      })
     } else {
       text = JSON.stringify(contents, null, this.options.indentation) + '\n'
     }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -900,6 +900,55 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    it('writes multiline output to yml', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({
+        output: 'locales/$LOCALE/$NAMESPACE.yml',
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('multiline', 'One\\nTwo')"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(path.normalize('en/translation.yml'))) {
+          result = file.contents.toString('utf8')
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.equal(result.replace(/\r\n/g, '\n'), `multiline: |-
+  One
+  Two
+`)
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
+    it('writes non-breaking space output to yml', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({
+        output: 'locales/$LOCALE/$NAMESPACE.yml',
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('nbsp', 'One\\u00A0Two')"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(path.normalize('en/translation.yml'))) {
+          result = file.contents.toString('utf8')
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.equal(result.replace(/\r\n/g, '\n'), 'nbsp: "One\\_Two"\n')
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     it('reads existing yml catalog', (done) => {
       let result
       const i18nextParser = new i18nTransform({

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -893,7 +893,7 @@ describe('parser', () => {
         }
       })
       i18nextParser.once('end', () => {
-        assert.equal(result.replace(/\r\n/g, '\n'), 'first: ""\n')
+        assert.equal(result.replace(/\r\n/g, '\n'), "first: ''\n")
         done()
       })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1530,6 +1530,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -1920,7 +1925,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -2458,6 +2463,14 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
+js-yaml@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -4084,14 +4097,6 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
-
-yamljs@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
-  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
-  dependencies:
-    argparse "^1.0.7"
-    glob "^7.0.5"
 
 yargs-parser@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
### Why am I submitting this PR

When outputting multiline content into a YAML file, it is now output as a multiline
entry, such as this:

```
multi-line-content: |
  <h1>This is multiline content</h1>
  <p>Isn't it nice</p>
```

Instead of like this:
```
multi-line-content: "<h1>This is multiline content\n<p>Isn't it nice?</p>\n"
```

### Does it fix an existing ticket?

Yes, #227 (although it's a side effect of using a better YAML library, and isn't the issue I was trying to fix!)

### Checklist

- [ x] only relevant code is changed (make a diff before you submit the PR)
- [ x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
