### PR TITLE
Outputting autoclosed tags when there's no child content

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -132,9 +132,9 @@ export default class JsxLexer extends JavascriptLexer {
                 this.transKeepBasicHtmlNodesFor.includes(child.name)
                   ? child.name
                   : index
-              return `<${elementName}>${elemsToString(
-                child.children
-              )}</${elementName}>`
+              const childrenString = elemsToString(child.children);
+              return childrenString ? `<${elementName}>${childrenString}</${elementName}>` :
+              `<${elementName} />`
             default:
               throw new Error('Unknown parsed content: ' + child.type)
           }

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -126,15 +126,15 @@ export default class JsxLexer extends JavascriptLexer {
             case 'text':
               return child.content
             case 'tag':
-              const elementName =
+              const useTagName =
                 child.isBasic &&
                 this.transSupportBasicHtmlNodes &&
                 this.transKeepBasicHtmlNodesFor.includes(child.name)
-                  ? child.name
-                  : index
-              const childrenString = elemsToString(child.children);
-              return childrenString ? `<${elementName}>${childrenString}</${elementName}>` :
-              `<${elementName} />`
+              const elementName = useTagName ? child.name : index
+              const childrenString = elemsToString(child.children)
+              return childrenString || !useTagName
+                ? `<${elementName}>${childrenString}</${elementName}>`
+                : `<${elementName} />`
             default:
               throw new Error('Unknown parsed content: ' + child.type)
           }

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -132,7 +132,7 @@ export default class JsxLexer extends JavascriptLexer {
                 this.transKeepBasicHtmlNodesFor.includes(child.name)
               const elementName = useTagName ? child.name : index
               const childrenString = elemsToString(child.children)
-              return childrenString || !useTagName
+              return childrenString || !(useTagName && child.selfClosing)
                 ? `<${elementName}>${childrenString}</${elementName}>`
                 : `<${elementName} />`
             default:
@@ -166,6 +166,7 @@ export default class JsxLexer extends JavascriptLexer {
             children: this.parseChildren(child.children, sourceText),
             name,
             isBasic,
+            selfClosing: child.kind === ts.SyntaxKind.JsxSelfClosingElement
           }
         } else if (child.kind === ts.SyntaxKind.JsxExpression) {
           // strip empty expressions

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -317,6 +317,20 @@ describe('JsxLexer', () => {
         assert.equal(Lexer.extract(content)[0].defaultValue, 'Some Content')
         done()
       })
+
+      it('output self-closing when transSupportBasicHtmlNodes is true and element is self-closing', (done) => {
+        const Lexer = new JsxLexer({transSupportBasicHtmlNodes: true})
+        const content = '<Trans>a<br />b</Trans>'
+        assert.equal(Lexer.extract(content)[0].defaultValue, 'a<br />b')
+        done()
+      })
+
+      it('do not output self-closing when transSupportBasicHtmlNodes is true but element is not self-closing', (done) => {
+        const Lexer = new JsxLexer({transSupportBasicHtmlNodes: true})
+        const content = '<Trans>a<strong></strong>b</Trans>'
+        assert.equal(Lexer.extract(content)[0].defaultValue, 'a<strong></strong>b')
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
Outputting stuff like `<br></br>` is creating issues in react when `transSupportBasicHtmlNodes` is `true`

### Why am I submitting this PR

When parsing autoclosed tags and having `transSupportBasicHtmlNodes = true` the parser outputs the not autoclosed version oh the tag, causing exceptions in react

### Does it fix an existing ticket?

No 

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
