### PR TITLE
Always emit a warning when key is not a string literal

### DIFF
--- a/dist/lexers/javascript-lexer.js
+++ b/dist/lexers/javascript-lexer.js
@@ -128,12 +128,12 @@ JavascriptLexer = function (_BaseLexer) {_inherits(JavascriptLexer, _BaseLexer);
           }
           entry.key = concatenatedString;
         } else {
-          if (keyArgument.kind === ts.SyntaxKind.Identifier) {
-            this.emit(
-            'warning', 'Key is not a string literal: ' +
-            keyArgument.text);
+          this.emit(
+          'warning',
+          keyArgument.kind === ts.SyntaxKind.Identifier ? 'Key is not a string literal: ' +
+          keyArgument.text :
+          'Key is not a string literal');
 
-          }
           return null;
         }
 

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -128,12 +128,12 @@ export default class JavascriptLexer extends BaseLexer {
         }
         entry.key = concatenatedString
       } else {
-        if (keyArgument.kind === ts.SyntaxKind.Identifier) {
-          this.emit(
-            'warning',
-            `Key is not a string literal: ${keyArgument.text}`
-          )
-        }
+        this.emit(
+          'warning',
+          keyArgument.kind === ts.SyntaxKind.Identifier
+            ? `Key is not a string literal: ${keyArgument.text}`
+            : 'Key is not a string literal'
+        )
         return null
       }
 

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -227,4 +227,20 @@ describe('JavascriptLexer', () => {
       },
     ])
   })
+
+  it('emits warnings on dynamic keys', () => {
+    const Lexer = new JavascriptLexer()
+    const content =
+      'const bar = "bar"; i18n.t("foo"); i18n.t(bar); i18n.t(`foo.${bar}`);'
+
+    let warningCount = 0
+    Lexer.on('warning', () => warningCount++)
+
+    assert.deepEqual(Lexer.extract(content), [
+      {
+        key: 'foo',
+      },
+    ])
+    assert.strictEqual(warningCount, 2)
+  })
 })


### PR DESCRIPTION
### Why am I submitting this PR

When running `i18next-parser` on my code, I heavily rely on it to find any keys that are built at runtime so I can add comment-hints or rework code to use static keys instead. Unfortunately, `i18next-parser` only emits warnings when the the key is a simple identifier but not when expressions are used.

Examples of code that do not emit the warning right now:
```js
t(`error.${errorCode}`);
t(cond ? "key1" : "key2");
```

This PR fixes that so that warnings will always be emitted.

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
- [x] I ran `yarn build` to compile and prettify the code
