### PR TITLE
Include Disable-Command

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -156,3 +156,12 @@ In recursive mode, it will parse `*.hbs` and `*.js` files and skip `.git` folder
 }))`
 
 This will output your files in the format `$LOCALE/client.$LOCALE.i18n.json` in a `i18n/` directory.
+
+**Ignore a single line from parsing**
+(Currently only on Js/Jsx/Vue-Lexers)
+Using a preceding comment the following line will not get parsed:
+
+```
+/* i18next-parser-disable-next-line */
+i18n.t('This will not get parsed')
+```

--- a/src/lexers/base-lexer.js
+++ b/src/lexers/base-lexer.js
@@ -32,6 +32,10 @@ export default class BaseLexer extends EventEmitter {
     return '(?:[A-Z0-9_.-]+)'
   }
 
+  static get disableLineRegex() {
+    return /i18next-parser-disable-next-line/
+  }
+
   static get stringPattern() {
     return (
       '(?:' +

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -24,7 +24,16 @@ export default class JsxLexer extends JavascriptLexer {
     const parseTree = (node) => {
       let entry
 
-      parseCommentNode(keys, node, content)
+      // Parse comment throws an error if disable-next-line is detected.
+      try {
+        parseCommentNode(keys, node, content)
+      } catch (error) {
+        if (error.context === 'disable-next-line') {
+          // Log disable and return to skip processing of this node
+          console.log('            Next line disabled.')
+          return
+        }
+      }
 
       switch (node.kind) {
         case ts.SyntaxKind.CallExpression:

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -247,4 +247,29 @@ describe('JavascriptLexer', () => {
     ])
     assert.strictEqual(warningCount, 2)
   })
+
+  it('Respect disable line comments', () => {
+    const Lexer = new JavascriptLexer()
+    const content = `
+      This needs a first line
+      // i18next-parser-disable-next-line
+      i18n.t('First not parsed')
+      i18n.t('First parsed')
+
+      /* i18next-parser-disable-next-line */
+      i18n.t('Second not parsed')
+      i18n.t('Second parsed')
+
+      /*
+       * i18next-parser-disable-next-line
+       */
+      i18n.t('Third not parsed')
+      i18n.t('Third parsed')
+      `
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'First parsed' },
+      { key: 'Second parsed' },
+      { key: 'Third parsed' },
+    ])
+  })
 })

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -335,5 +335,30 @@ describe('JsxLexer', () => {
         done()
       })
     })
+
+    it('Respect disable line comments', () => {
+      const Lexer = new JsxLexer()
+      const content = `
+        This unfortunately needs a first line
+        // i18next-parser-disable-next-line
+        i18n.t('First not parsed')
+        i18n.t('First parsed')
+
+        /* i18next-parser-disable-next-line */
+        i18n.t('Second not parsed')
+        i18n.t('Second parsed')
+
+        /*
+        * i18next-parser-disable-next-line
+        */
+        i18n.t('Third not parsed')
+        i18n.t('Third parsed')
+        `
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'First parsed' },
+        { key: 'Second parsed' },
+        { key: 'Third parsed' },
+      ])
+    })
   })
 })

--- a/test/lexers/vue-lexer.test.js
+++ b/test/lexers/vue-lexer.test.js
@@ -62,4 +62,29 @@ describe('VueLexer', () => {
     ])
     done()
   })
+
+  it('Respect disable line comments', () => {
+    const Lexer = new VueLexer()
+    const content = `
+      This unfortunately needs a first line
+      // i18next-parser-disable-next-line
+      i18n.t('First not parsed')
+      i18n.t('First parsed')
+
+      /* i18next-parser-disable-next-line */
+      i18n.t('Second not parsed')
+      i18n.t('Second parsed')
+
+      /*
+       * i18next-parser-disable-next-line
+       */
+      i18n.t('Third not parsed')
+      i18n.t('Third parsed')
+      `
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'First parsed' },
+      { key: 'Second parsed' },
+      { key: 'Third parsed' },
+    ])
+  })
 })


### PR DESCRIPTION
### Why am I submitting this PR
See #263, i just wanted to give it a go.
Unfortunately i'm quite confused by this typescript implementation of the lexer and the completely different implementations on the different lexers, and i have no idea, if my attempt could be done better. This works now mostly, i just recognized two small problems, which imo shouldn't be too much of a problem in practice, but honestly prevent the feature from beeing presented as error-free:
- If the disable-comment is the very first line of the file, the whole file is skipped. This seems to be a problem of this node-handling, but i have no idea, what exactly happens with those nodes.
- If a code-line with a trailing dot is right before the comment, then the disable-comment is skipped and the line gets parsed even that it should not. (Probably a general problem of the CommentNodeParser?)

Unfortunately i'm about to give up, so if you can tell me some smaller fixes to make this mergable, just tell me. However if this would need some larger rework just close the PR, i just don't have the time to dig deeper into here... 😞 

### Does it fix an existing ticket?

Partially #263 for Javascript/Jsx/Vue-Lexers

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
- [?] I ran `yarn build` to compile and prettify the code -- Not yarn, but `npm run build`?! 🤔 
