### PR TITLE
Add the ability to configure plural separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ module.exports = {
   // Supports JSON (.json) and YAML (.yml) file formats
   // Where to write the locale files relative to process.cwd()
 
+  pluralSeparator: '_',
+  // Plural separator used in your translation keys
+  // If you want to use plain english keys, separators such as `_` might conflict. You might want to set `pluralSeparator` to a different string that does not occur in your keys.
+
   input: undefined,
   // An array of globs that describe where to look for source files
   // relative to the location of the configuration file

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -14,7 +14,7 @@
 function dotPathToHash(entry) {var target = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
   var path = entry.keyWithNamespace;
   if (options.suffix || options.suffix === 0) {
-    path += "_".concat(options.suffix);
+    path += "".concat(options.pluralSeparator).concat(options.suffix);
   }
 
   var separator = options.separator || '.';

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -34,6 +34,7 @@ i18nTransform = /*#__PURE__*/function (_Transform) {_inherits(i18nTransform, _Tr
       lineEnding: 'auto',
       locales: ['en', 'fr'],
       namespaceSeparator: ':',
+      pluralSeparator: '_',
       output: 'locales/$LOCALE/$NAMESPACE.json',
       sort: false,
       useKeysAsDefaultValue: false,
@@ -141,6 +142,7 @@ i18nTransform = /*#__PURE__*/function (_Transform) {_inherits(i18nTransform, _Tr
             var _dotPathToHash = (0, _helpers.dotPathToHash)(entry, catalog, {
               suffix: suffix,
               separator: _this2.options.keySeparator,
+              pluralSeparator: _this2.options.pluralSeparator,
               value: _this2.options.defaultValue,
               useKeysAsDefaultValue: _this2.options.useKeysAsDefaultValue,
               skipDefaultValues: _this2.options.skipDefaultValues,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,7 +14,7 @@
 function dotPathToHash(entry, target = {}, options = {}) {
   let path = entry.keyWithNamespace
   if (options.suffix || options.suffix === 0) {
-    path += `_${options.suffix}`
+    path += `${options.pluralSeparator}${options.suffix}`
   }
 
   const separator = options.separator || '.'

--- a/src/transform.js
+++ b/src/transform.js
@@ -34,6 +34,7 @@ export default class i18nTransform extends Transform {
       lineEnding: 'auto',
       locales: ['en', 'fr'],
       namespaceSeparator: ':',
+      pluralSeparator: '_',
       output: 'locales/$LOCALE/$NAMESPACE.json',
       sort: false,
       useKeysAsDefaultValue: false,
@@ -141,6 +142,7 @@ export default class i18nTransform extends Transform {
         const { duplicate, conflict } = dotPathToHash(entry, catalog, {
           suffix,
           separator: this.options.keySeparator,
+          pluralSeparator: this.options.pluralSeparator,
           value: this.options.defaultValue,
           useKeysAsDefaultValue: this.options.useKeysAsDefaultValue,
           skipDefaultValues: this.options.skipDefaultValues,

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1089,6 +1089,32 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    it('generates plurals with custom plural separator', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({
+        pluralSeparator: '~~~',
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('test {{count}}', { count: 1 })"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(enLibraryPath)) {
+          result = JSON.parse(file.contents)
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.deepEqual(result, {
+          'test {{count}}': '',
+          'test {{count}}~~~plural': '',
+        })
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     it('generates one plural key for unknow languages', (done) => {
       let result
       const i18nextParser = new i18nTransform({ locales: ['unknown'] })


### PR DESCRIPTION
### Why am I submitting this PR

I would like to be able to configure the plural separator, just like the key, namespace, and context separator.

### Does it fix an existing ticket?

Closes https://github.com/i18next/i18next-parser/issues/300

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [X] documentation is changed or added
- [X] I ran `yarn build` to compile and prettify the code
