### PR TITLE
Improve behaviour for missing defaults

### DIFF
--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -83,7 +83,15 @@ function dotPathToHash(entry) {var target = arguments.length > 1 && arguments[1]
   var lastSegment = segments[segments.length - 1];
   var oldValue = inner[lastSegment];
   if (oldValue !== undefined && oldValue !== newValue) {
-    conflict = (0, _typeof2["default"])(oldValue) !== (0, _typeof2["default"])(newValue) ? 'key' : 'value';
+    if ((0, _typeof2["default"])(oldValue) !== (0, _typeof2["default"])(newValue)) {
+      conflict = 'key';
+    } else if (oldValue !== '') {
+      if (newValue === '') {
+        newValue = oldValue;
+      } else {
+        conflict = 'value';
+      }
+    }
   }
   duplicate = oldValue !== undefined || conflict !== false;
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -83,7 +83,15 @@ function dotPathToHash(entry, target = {}, options = {}) {
   const lastSegment = segments[segments.length - 1]
   const oldValue = inner[lastSegment]
   if (oldValue !== undefined && oldValue !== newValue) {
-    conflict = typeof oldValue !== typeof newValue ? 'key' : 'value'
+    if (typeof oldValue !== typeof newValue) {
+      conflict = 'key'
+    } else if (oldValue !== '') {
+      if (newValue === '') {
+        newValue = oldValue
+      } else {
+        conflict = 'value'
+      }
+    }
   }
   duplicate = oldValue !== undefined || conflict !== false
 

--- a/test/helpers/dotPathToHash.test.js
+++ b/test/helpers/dotPathToHash.test.js
@@ -128,4 +128,26 @@ describe('dotPathToHash helper function', () => {
     assert.equal(conflict, 'key')
     done()
   })
+
+  it('uses old value when there is no new value and does not conflict', (done) => {
+    const { target, duplicate, conflict } = dotPathToHash(
+      { keyWithNamespace: 'one.two.three' },
+      { one: { two: { three: 'old' } } }
+    )
+    assert.deepEqual(target, { one: { two: { three: 'old' } } })
+    assert.equal(duplicate, true)
+    assert.equal(conflict, false)
+    done()
+  })
+
+  it('uses new value when there is no old value and does not conflict', (done) => {
+    const { target, duplicate, conflict } = dotPathToHash(
+      { keyWithNamespace: 'one.two.three', defaultValue: 'new' },
+      { one: { two: { three: '' } } }
+    )
+    assert.deepEqual(target, { one: { two: { three: 'new' } } })
+    assert.equal(duplicate, true)
+    assert.equal(conflict, false)
+    done()
+  })
 })


### PR DESCRIPTION
### Why am I submitting this PR

I think it would be better if warnings were not generated for multiple instances of the same key where one is missing a default value.  Furthermore, there is an asymmetry in the current behaviour where default values only appear in the json if they are discovered last. Consider input A and input B.

#### input A
```ts
const myKeyNoDefault = t('my.key');
const myKey = t('my.key', 'foobar');
```

#### output A (current behaviour)

```
  [read]    /path/to/file.ts
  [warning] Found same keys with different values: my.key
```

```json
{
    "my": {
        "key": "foobar"
    }
}
```

#### input B
```ts
const myKey = t('my.key', 'foobar');
const myKeyNoDefault = t('my.key');
```

#### output B (current behaviour)

```
  [read]    /path/to/file.ts
  [warning] Found same keys with different values: my.key
```

```json
{
    "my": {
        "key": ""
    }
}
```

I think it would be better if it didn't generate a warning, and that you always got the default value regardless of the order.

#### output B (changed in this PR)

```
  [read]    /path/to/file.ts
```

```json
{
    "my": {
        "key": "foobar"
    }
}
```

#### input C

Of course you should still get a warning for doing something like this.

```ts
const myKey = t('my.key', 'foobar');
const myKeyNoDefault = t('my.key');
const myKeyDifferentDefault = t('my.key', 'bazquux');
```

#### output C (behaviour unchanged)
```
  [read]    /path/to/file.ts
  [warning] Found same keys with different values: my.key
```

```json
{
    "my": {
        "key": "bazquux"
    }
}
```
### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
- [x] I ran `yarn build` to compile and prettify the code
