### PR TITLE
Support unicode escape sequence in json

### DIFF
--- a/dist/transform.js
+++ b/dist/transform.js
@@ -294,6 +294,11 @@ i18nTransform = /*#__PURE__*/function (_Transform) {(0, _inherits2["default"])(i
 
       } else {
         text = JSON.stringify(contents, null, this.options.indentation) + '\n';
+        // Convert non-ASCII characters to unicode escape sequence
+        text = text.replace(
+        /[\u007F-\uFFFF]/g,
+        function (chr) {return "\\u".concat("0000".concat(chr.charCodeAt(0).toString(16)).substr(-4));});
+
       }
 
       if (this.options.lineEnding === 'auto') {

--- a/src/transform.js
+++ b/src/transform.js
@@ -294,6 +294,8 @@ export default class i18nTransform extends Transform {
       })
     } else {
       text = JSON.stringify(contents, null, this.options.indentation) + '\n'
+      // Convert non-ASCII characters to unicode escape sequence
+      text = text.replace(/[\u007F-\uFFFF]/g, (chr) => `\\u${`0000${chr.charCodeAt(0).toString(16)}`.substr(-4)}`)
     }
 
     if (this.options.lineEnding === 'auto') {

--- a/src/transform.js
+++ b/src/transform.js
@@ -295,7 +295,10 @@ export default class i18nTransform extends Transform {
     } else {
       text = JSON.stringify(contents, null, this.options.indentation) + '\n'
       // Convert non-ASCII characters to unicode escape sequence
-      text = text.replace(/[\u007F-\uFFFF]/g, (chr) => `\\u${`0000${chr.charCodeAt(0).toString(16)}`.substr(-4)}`)
+      text = text.replace(
+        /[\u007F-\uFFFF]/g,
+        (chr) => `\\u${`0000${chr.charCodeAt(0).toString(16)}`.substr(-4)}`
+      )
     }
 
     if (this.options.lineEnding === 'auto') {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -990,6 +990,31 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    it('writes non-breaking space output to json', (done) => {
+      let result
+      const expected = '{\n  "nbsp": "One\\u00a0Two\\u00a0Three"\n}\n'
+
+      const i18nextParser = new i18nTransform({
+        output: 'locales/$LOCALE/$NAMESPACE.json',
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('nbsp', 'One\\u00A0Two\\u00a0Three')"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(path.normalize('en/translation.json'))) {
+          result = file.contents.toString('utf8')
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.equal(result, expected)
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     it('supports outputing to yml', (done) => {
       let result
       const i18nextParser = new i18nTransform({


### PR DESCRIPTION
### Why am I submitting this PR

When using unicode escape sequences, the parser converts them to utf8. This PR should allow to preserve them.

Be aware that this PR will also convert all non-ASCII characters to its unicode escape sequences as well. Personally, I find it best to make these characters explicit, but let me know if you'd like to see this behavior as an option.
Moreover, note that the case is not preserved inside the unicode escape sequences, it will always be lowercased (`\u00A0` will become `\u00a0`).


### Does it fix an existing ticket?

Yes #361 

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
- [x] I ran `yarn build` to compile and prettify the code
