### PR TITLE
fix: added support for string arrays as an argument to the useTranslation

### DIFF
--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -4,7 +4,7 @@ import * as ts from 'typescript'
 export default class JavascriptLexer extends BaseLexer {
   constructor(options = {}) {
     super(options)
-    this.namespaceSeparator = options.namespaceSeparator;
+
     this.callPattern = '(?<=^|\\s|\\.)' + this.functionPattern() + '\\(.*\\)'
     this.functions = options.functions || ['t']
     this.attr = options.attr || 'i18nKey'
@@ -138,17 +138,7 @@ export default class JavascriptLexer extends BaseLexer {
         keyArgument.kind === ts.SyntaxKind.StringLiteral ||
         keyArgument.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral
       ) {
-        if (this.namespaceSeparator) {
-          const [ns, key] = keyArgument.text.split(this.namespaceSeparator, 2);
-          if (key) {
-            entry.key = key;
-            entry.ns = ns;
-          } else {
-            entry.key = keyArgument.text
-          }
-        } else {
-          entry.key = keyArgument.text
-        }
+        entry.key = keyArgument.text
       } else if (keyArgument.kind === ts.SyntaxKind.BinaryExpression) {
         const concatenatedString = this.concatenateString(keyArgument)
         if (!concatenatedString) {

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -110,14 +110,8 @@ export default class JavascriptLexer extends BaseLexer {
     const entry = {}
 
     if (
-      node.expression.escapedText === 'useTranslation' &&
-      node.arguments.length
-    ) {
-      this.defaultNamespace = node.arguments[0].text
-    }
-
-    if (
-      node.expression.escapedText === 'withTranslation' &&
+      (node.expression.escapedText === 'useTranslation' ||
+      node.expression.escapedText === 'withTranslation') &&
       node.arguments.length
     ) {
       const { text, elements } = node.arguments[0]

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -4,7 +4,7 @@ import * as ts from 'typescript'
 export default class JavascriptLexer extends BaseLexer {
   constructor(options = {}) {
     super(options)
-
+    this.namespaceSeparator = options.namespaceSeparator;
     this.callPattern = '(?<=^|\\s|\\.)' + this.functionPattern() + '\\(.*\\)'
     this.functions = options.functions || ['t']
     this.attr = options.attr || 'i18nKey'
@@ -138,7 +138,17 @@ export default class JavascriptLexer extends BaseLexer {
         keyArgument.kind === ts.SyntaxKind.StringLiteral ||
         keyArgument.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral
       ) {
-        entry.key = keyArgument.text
+        if (this.namespaceSeparator) {
+          const [ns, key] = keyArgument.text.split(this.namespaceSeparator, 2);
+          if (key) {
+            entry.key = key;
+            entry.ns = ns;
+          } else {
+            entry.key = keyArgument.text
+          }
+        } else {
+          entry.key = keyArgument.text
+        }
       } else if (keyArgument.kind === ts.SyntaxKind.BinaryExpression) {
         const concatenatedString = this.concatenateString(keyArgument)
         if (!concatenatedString) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -70,7 +70,7 @@ export default class Parser extends EventEmitter {
         Lexer = lexersMap[lexerName]
       }
 
-      const lexer = new Lexer({ ...this.options, ...lexerOptions})
+      const lexer = new Lexer(lexerOptions)
       lexer.on('warning', (warning) => this.emit('warning', warning))
       keys = keys.concat(lexer.extract(content, filename))
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -70,7 +70,7 @@ export default class Parser extends EventEmitter {
         Lexer = lexersMap[lexerName]
       }
 
-      const lexer = new Lexer(lexerOptions)
+      const lexer = new Lexer({ ...this.options, ...lexerOptions})
       lexer.on('warning', (warning) => this.emit('warning', warning))
       keys = keys.concat(lexer.extract(content, filename))
     }

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -189,6 +189,15 @@ describe('JavascriptLexer', () => {
       ])
     })
 
+    it('extracts first namespace when it is an array', () => {
+      const Lexer = new JavascriptLexer()
+      const content =
+        'const ExtendedComponent = useTranslation(["foo", "baz"]); t("bar");'
+      assert.deepEqual(Lexer.extract(content), [
+        { namespace: 'foo', key: 'bar' },
+      ])
+    })
+
     it('uses namespace from t function with priority', () => {
       const Lexer = new JavascriptLexer()
       const content =

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -189,30 +189,12 @@ describe('JavascriptLexer', () => {
       ])
     })
 
-    it('extracts first namespace when it is an array', () => {
-      const Lexer = new JavascriptLexer()
-      const content =
-        'const ExtendedComponent = useTranslation(["foo", "baz"]); t("bar");'
-      assert.deepEqual(Lexer.extract(content), [
-        { namespace: 'foo', key: 'bar' },
-      ])
-    })
-
     it('uses namespace from t function with priority', () => {
       const Lexer = new JavascriptLexer()
       const content =
         'const {t} = useTranslation("foo"); t("bar", {ns: "baz"});'
       assert.deepEqual(Lexer.extract(content), [
         { namespace: 'baz', key: 'bar', ns: 'baz' },
-      ])
-    })
-
-    it('uses namespace separator', () => {
-      const Lexer = new JavascriptLexer({ namespaceSeparator: ':'})
-      const content = 'const {t} = useTranslation(["foo", "baz"]); t("baz:bar"); t("qux");'
-      assert.deepEqual(Lexer.extract(content), [
-        { key: 'bar', ns: 'baz', namespace: 'baz' },
-        { key: 'qux', namespace: 'foo' }
       ])
     })
   })
@@ -242,16 +224,6 @@ describe('JavascriptLexer', () => {
         'const ExtendedComponent = withTranslation("foo")(MyComponent); t("bar", {ns: "baz"});'
       assert.deepEqual(Lexer.extract(content), [
         { namespace: 'baz', key: 'bar', ns: 'baz' },
-      ])
-    })
-
-    it('uses namespace separator', () => {
-      const Lexer = new JavascriptLexer({ namespaceSeparator: ':'})
-      const content =
-        'const {t} = withTranslation(["foo", "baz"])(MyComponent); t("baz:bar"); t("qux");'
-      assert.deepEqual(Lexer.extract(content), [
-        { key: 'bar', ns: 'baz', namespace: 'baz' },
-        { key: 'qux', namespace: 'foo' }
       ])
     })
   })

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -189,12 +189,30 @@ describe('JavascriptLexer', () => {
       ])
     })
 
+    it('extracts first namespace when it is an array', () => {
+      const Lexer = new JavascriptLexer()
+      const content =
+        'const ExtendedComponent = useTranslation(["foo", "baz"]); t("bar");'
+      assert.deepEqual(Lexer.extract(content), [
+        { namespace: 'foo', key: 'bar' },
+      ])
+    })
+
     it('uses namespace from t function with priority', () => {
       const Lexer = new JavascriptLexer()
       const content =
         'const {t} = useTranslation("foo"); t("bar", {ns: "baz"});'
       assert.deepEqual(Lexer.extract(content), [
         { namespace: 'baz', key: 'bar', ns: 'baz' },
+      ])
+    })
+
+    it('uses namespace separator', () => {
+      const Lexer = new JavascriptLexer({ namespaceSeparator: ':'})
+      const content = 'const {t} = useTranslation(["foo", "baz"]); t("baz:bar"); t("qux");'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'bar', ns: 'baz', namespace: 'baz' },
+        { key: 'qux', namespace: 'foo' }
       ])
     })
   })
@@ -224,6 +242,16 @@ describe('JavascriptLexer', () => {
         'const ExtendedComponent = withTranslation("foo")(MyComponent); t("bar", {ns: "baz"});'
       assert.deepEqual(Lexer.extract(content), [
         { namespace: 'baz', key: 'bar', ns: 'baz' },
+      ])
+    })
+
+    it('uses namespace separator', () => {
+      const Lexer = new JavascriptLexer({ namespaceSeparator: ':'})
+      const content =
+        'const {t} = withTranslation(["foo", "baz"])(MyComponent); t("baz:bar"); t("qux");'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'bar', ns: 'baz', namespace: 'baz' },
+        { key: 'qux', namespace: 'foo' }
       ])
     })
   })


### PR DESCRIPTION
### Why am I submitting this PR

added support for string arrays as an argument to the useTranslation

### Does it fix an existing ticket?

Yes/No #305

### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
- [ ] I ran `yarn build` to compile and prettify the code
