### PR TITLE
chore(ci): use setup-node native cache and major version of actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,21 +13,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2.4.0
+      uses: actions/setup-node@v2
       with:
+        cache: npm
         node-version: ${{ matrix.node-version }}
-    - name: Cache Node.js modules
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
     - run: npm install
     - run: npm run build
     - run: npm run coverage
-    - uses: codecov/codecov-action@v2.0.3
+    - uses: codecov/codecov-action@v2
       with: 
         name: node-${{ matrix.node-version }}
         fail_ci_if_error: false


### PR DESCRIPTION
### Why am I submitting this PR

HI ! This PR is to use the native cache of setup-node@v2 and use major versions of setup-node and codecov-action
It will avoid to have a PR for every new minor or patch version of those.

### Does it fix an existing ticket?

No

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [ ] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
- [ ] I ran `yarn build` to compile and prettify the code
