### PR TITLE
Escape non-printable Unicode characters

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -294,6 +294,12 @@ export default class i18nTransform extends Transform {
       })
     } else {
       text = JSON.stringify(contents, null, this.options.indentation) + '\n'
+      // Convert non-printable Unicode characters to unicode escape sequence
+      // https://unicode.org/reports/tr18/#General_Category_Property
+      text = text.replace(/[\p{Z}\p{Cc}\p{Cf}]/gu, (chr) => {
+        const n = chr.charCodeAt(0)
+        return n < 128 ? chr : `\\u${`0000${n.toString(16)}`.substr(-4)}`
+      })
     }
 
     if (this.options.lineEnding === 'auto') {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -990,6 +990,31 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    it('writes non-breaking space output to json', (done) => {
+      let result
+      const expected = '{\n  "nbsp": "Oné\\u00a0Twó\\u3000Three Four"\n}\n'
+
+      const i18nextParser = new i18nTransform({
+        output: 'locales/$LOCALE/$NAMESPACE.json',
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('nbsp', 'Oné\\u00A0Twó\\u3000Three Four')"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(path.normalize('en/translation.json'))) {
+          result = file.contents.toString('utf8')
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.equal(result, expected)
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     it('supports outputing to yml', (done) => {
       let result
       const i18nextParser = new i18nTransform({


### PR DESCRIPTION
Revert d3858b6dd1399cf9bf2fa6c36de93f7bab693380

Changed #362 to escape only non-printable Unicode character.

### Why am I submitting this PR

Enhanced version of #362. Escaping only Unicode Separators `\p{Z}`, Control `\p{Cc}` and Format `\p{Cf}` characters ([doc](https://unicode.org/reports/tr18/#General_Category_Property)).

See also: [node.green](https://node.green/#ES2018-features--RegExp-Unicode-Property-Escapes), [caniuse](https://caniuse.com/mdn-javascript_builtins_regexp_property_escapes).

Tested also in proprietary project with Cyrillic translation files.
@kobrynsky, @damien-monni, @bodryi (menthioned from #362), feel free to test it in your projects too.

### Does it fix an existing ticket?

Yes #361

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
- [ ] I ran `yarn build` to compile and prettify the code
