### PR TITLE
Add template literal support for `defaultValue` as a second argument (#419)

### DIFF
--- a/dist/lexers/javascript-lexer.js
+++ b/dist/lexers/javascript-lexer.js
@@ -163,8 +163,9 @@ JavascriptLexer = /*#__PURE__*/function (_BaseLexer) {(0, _inherits2["default"])
 
         // Second argument could be a string default value
         if (
-        optionsArgument &&
-        optionsArgument.kind === ts.SyntaxKind.StringLiteral)
+        optionsArgument && (
+        optionsArgument.kind === ts.SyntaxKind.StringLiteral ||
+        optionsArgument.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral))
         {
           entry.defaultValue = optionsArgument.text;
           optionsArgument = node.arguments.shift();

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -164,7 +164,8 @@ export default class JavascriptLexer extends BaseLexer {
       // Second argument could be a string default value
       if (
         optionsArgument &&
-        optionsArgument.kind === ts.SyntaxKind.StringLiteral
+        (optionsArgument.kind === ts.SyntaxKind.StringLiteral ||
+          optionsArgument.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral)
       ) {
         entry.defaultValue = optionsArgument.text
         optionsArgument = node.arguments.shift()

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -10,9 +10,18 @@ describe('JavascriptLexer', () => {
     done()
   })
 
-  it('extracts the second argument as defaultValue', (done) => {
+  it('extracts the second argument string literal as defaultValue', (done) => {
     const Lexer = new JavascriptLexer()
     const content = 'i18n.t("first", "bla")'
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'first', defaultValue: 'bla' },
+    ])
+    done()
+  })
+
+  it('extracts the second argument template literal as defaultValue', (done) => {
+    const Lexer = new JavascriptLexer()
+    const content = 'i18n.t("first", `bla`)'
     assert.deepEqual(Lexer.extract(content), [
       { key: 'first', defaultValue: 'bla' },
     ])


### PR DESCRIPTION
### Why am I submitting this PR

It adds template literal support for `defaultValue` as a second argument.

### Does it fix an existing ticket?

Yes #419 

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
- [x] I ran `yarn build` to compile and prettify the code
