### PR TITLE
Add resetDefaultValueLocale option

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ module.exports = {
   failOnUpdate: false,
   // Exit with an exit code of 1 when translations are updated (for CI purpose)
 
-  customValueTemplate: null
+  customValueTemplate: null,
   // If you wish to customize the value output the value as an object, you can set your own format.
   // ${defaultValue} is the default value you set in your translation function.
   // Any other custom property will be automatically extracted.
@@ -210,6 +210,12 @@ module.exports = {
   //   message: "${defaultValue}",
   //   description: "${maxLength}", // t('my-key', {maxLength: 150})
   // }
+
+  resetDefaultValueLocale: null
+  // The locale to compare with default values to determine whether a default value has been changed.
+  // If this is set and a default value differs from a translation in the specified locale, all entries
+  // for that key across locales are reset to the default value, and existing translations are moved to
+  // the `_old` file.
 }
 ```
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -33,6 +33,7 @@ export default class i18nTransform extends Transform {
       namespaceSeparator: ':',
       pluralSeparator: '_',
       output: 'locales/$LOCALE/$NAMESPACE.json',
+      resetDefaultValueLocale: null,
       sort: false,
       useKeysAsDefaultValue: false,
       verbose: false,
@@ -126,8 +127,20 @@ export default class i18nTransform extends Transform {
   }
 
   _flush(done) {
-    for (const locale of this.options.locales) {
+    let maybeSortedLocales = this.options.locales
+    if (this.options.resetDefaultValueLocale) {
+      // ensure we process the reset locale first
+      maybeSortedLocales.sort((a) =>
+        a === this.options.resetDefaultValueLocale ? -1 : 1
+      )
+    }
+
+    // Tracks keys to reset by namespace
+    let resetValues = {}
+
+    for (const locale of maybeSortedLocales) {
       const catalog = {}
+      const resetAndFlag = this.options.resetDefaultValueLocale === locale
 
       let countWithPlurals = 0
       let uniqueCount = this.entries.length
@@ -194,7 +207,23 @@ export default class i18nTransform extends Transform {
           old: oldKeys,
           mergeCount,
           oldCount,
-        } = mergeHashes(existingCatalog, catalog[namespace], this.options)
+          reset: resetFlags,
+          resetCount,
+        } = mergeHashes(
+          existingCatalog,
+          catalog[namespace],
+          {
+            ...this.options,
+            resetAndFlag,
+          },
+          resetValues[namespace]
+        )
+
+        // record values to be reset
+        // assumes that the 'default' namespace is processed first
+        if (resetAndFlag && !resetValues[namespace]) {
+          resetValues[namespace] = resetFlags
+        }
 
         // restore old translations
         const { old: oldCatalog, mergeCount: restoreCount } = mergeHashes(
@@ -218,6 +247,9 @@ export default class i18nTransform extends Transform {
             console.log(`Unreferenced keys: ${oldCount}`)
           } else {
             console.log(`Removed keys: ${oldCount}`)
+          }
+          if (this.options.resetDefaultValueLocale) {
+            console.log(`Reset keys: ${resetCount}`)
           }
           console.log()
         }

--- a/test/helpers/mergeHashes.test.js
+++ b/test/helpers/mergeHashes.test.js
@@ -228,4 +228,40 @@ describe('mergeHashes helper function', () => {
     assert.strictEqual(res.oldCount, 0)
     done()
   })
+
+  it('resets keys to the target value if they are flagged in the resetKeys object', (done) => {
+    const source = { key1: 'key1', key2: 'key2' }
+    const target = { key1: 'changedKey1', key2: 'changedKey2' }
+    const res = mergeHashes(source, target, {}, { key1: true })
+
+    assert.deepEqual(res.new, { key1: 'changedKey1', key2: 'key2' })
+    assert.deepEqual(res.old, { key1: 'key1' })
+    assert.strictEqual(res.resetCount, 1)
+    done()
+  })
+
+  it('ignores keys if they are plurals', (done) => {
+    const source = { key1_one: 'key1', key2: 'key2' }
+    const target = { key1_one: 'changedKey1', key2: 'changedKey2' }
+    const res = mergeHashes(source, target, {}, { key1: true })
+
+    assert.deepEqual(res.new, { key1_one: 'key1', key2: 'key2' })
+    assert.deepEqual(res.old, {})
+    assert.strictEqual(res.resetCount, 0)
+    done()
+  })
+
+  it('resets and flags keys if the resetAndFlag value is set', (done) => {
+    const source = { key1: 'key1', key2: 'key2' }
+    const target = { key1: 'changedKey1', key2: 'key2' }
+    const res = mergeHashes(source, target, {
+      resetAndFlag: true,
+    })
+
+    assert.deepEqual(res.new, { key1: 'changedKey1', key2: 'key2' })
+    assert.deepEqual(res.old, { key1: 'key1' })
+    assert.deepEqual(res.reset, { key1: true })
+    assert.strictEqual(res.resetCount, 1)
+    done()
+  })
 })

--- a/test/locales/ar/test_reset.json
+++ b/test/locales/ar/test_reset.json
@@ -1,0 +1,3 @@
+{
+  "key": "ar_translation"
+}

--- a/test/locales/en/test_reset.json
+++ b/test/locales/en/test_reset.json
@@ -1,0 +1,3 @@
+{
+  "key": "en_translation"
+}

--- a/test/locales/fr/test_reset.json
+++ b/test/locales/fr/test_reset.json
@@ -1,0 +1,3 @@
+{
+  "key": "defaultTranslation"
+}


### PR DESCRIPTION
### Why am I submitting this PR

Add a feature related to resetting translations for a key if the default value changes.

### Does it fix an existing ticket?

Yes #267 

### Checklist

- [ X] only relevant code is changed (make a diff before you submit the PR)
- [ X] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ X] documentation is changed or added
