### PR TITLE
Parsing type details from typescript files

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,14 +5,15 @@
 This will create the files in the specified folder.
 
 ### Command line
+
 ```
 $ i18next /path/to/file/or/dir -o /translations/$LOCALE/$NAMESPACE.json
-$ i18next /path/to/file/or/dir:/translations/$LOCALE/$NAMESPACE.json 
+$ i18next /path/to/file/or/dir:/translations/$LOCALE/$NAMESPACE.json
 ```
 
 ### Gulp
 
-When using Gulp, note that the files are not created until `dest()` is called. 
+When using Gulp, note that the files are not created until `dest()` is called.
 
 ```js
 .pipe(i18next({ output: 'translations/$LOCALE/$NAMESPACE.json' }))
@@ -39,6 +40,7 @@ Add the `locales` option to the config file:
 ```
 
 ### Gulp
+
 ```js
 .pipe(i18next({ locales: ['en', 'de', 'sp'] })
 ```
@@ -112,23 +114,72 @@ _e "key"
 ```
 
 Add the `function` property to the related lexer in the config file:
+
 ```js
 {
   lexers: {
-    js: [{
-      lexer: 'JavascriptLexer',
-      functions: ['t', 'TAPi18n.__', '__']
-    }]
-  }  
+    js: [
+      {
+        lexer: 'JavascriptLexer',
+        functions: ['t', 'TAPi18n.__', '__'],
+      },
+    ]
+  }
+}
+```
+
+Add the `parseGenerics` (as well as `typeMap`) if you want to parse the data from the generic types in typescript
+
+```js
+{
+  lexers: {
+    js: [
+      {
+        lexer: 'JavascriptLexer',
+        parseGenerics: true,
+        typeMap: { CountType: { count: '' } },
+      },
+    ]
+  }
+}
+```
+
+So that the parser can detect typescript code like :
+
+```ts
+const MyKey T<{count: number}>('my_key');
+
+type CountType = {count : number};
+const MyOtherKey = T<CountType>('my_other_key');
+
+i18next.t(MyKey, {count: 1});
+i18next.t(MyOtherKey, {count: 2});
+```
+
+and generate the correct keys
+
+```js
+{
+  lexers: {
+    js: [
+      {
+        lexer: 'JavascriptLexer',
+        functions: ['t', 'TAPi18n.__', '__'],
+      },
+    ]
+  }
 }
 ```
 
 Please note that:
+
 - We don't match the closing parenthesis, as you might want to pass arguments to your translation function;
 - The parser is smart about escaped quotes (single or double) you may have in your key.
 
-## Work with Meteor TAP-i18N (gulp)**
+## Work with Meteor TAP-i18N (gulp)\*\*
+
 en', 'de', 'sp
+
 ```js
 .pipe(i18next({
     output: "i18n/$LOCALE/$NAMESPACE.$LOCALE.i18n.json",

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -8,6 +8,7 @@ export default class JavascriptLexer extends BaseLexer {
     this.callPattern = '(?<=^|\\s|\\.)' + this.functionPattern() + '\\(.*\\)'
     this.functions = options.functions || ['t']
     this.attr = options.attr || 'i18nKey'
+    this.parseGenerics = options.parseGenerics || false
     this.typeMap = options.typeMap || {}
   }
 
@@ -160,24 +161,26 @@ export default class JavascriptLexer extends BaseLexer {
         return null
       }
 
-      let typeArgument = node.typeArguments.shift()
+      if (this.parseGenerics) {
+        let typeArgument = node.typeArguments.shift()
 
-      const parseTypeArgument = (typeArg) => {
-        if (typeArg) {
-          if (typeArg.kind === ts.SyntaxKind.TypeLiteral) {
-            for (const member of typeArg.members) {
-              entry[member.name.text] = ''
-            }
-          } else if (typeArg.kind === ts.SyntaxKind.TypeReference) {
-            if (typeArg.typeName.kind === ts.SyntaxKind.Identifier) {
-              const typeName = typeArg.typeName.text
-              if (typeName in this.typeMap) {
-                Object.assign(entry, this.typeMap[typeName])
+        const parseTypeArgument = (typeArg) => {
+          if (typeArg) {
+            if (typeArg.kind === ts.SyntaxKind.TypeLiteral) {
+              for (const member of typeArg.members) {
+                entry[member.name.text] = ''
               }
-            }
-          } else {
-            if (Array.isArray(typeArg.types)) {
-              for (const tp of typeArgument.types) parseTypeArgument(tp)
+            } else if (typeArg.kind === ts.SyntaxKind.TypeReference) {
+              if (typeArg.typeName.kind === ts.SyntaxKind.Identifier) {
+                const typeName = typeArg.typeName.text
+                if (typeName in this.typeMap) {
+                  Object.assign(entry, this.typeMap[typeName])
+                }
+              }
+            } else {
+              if (Array.isArray(typeArg.types)) {
+                for (const tp of typeArgument.types) parseTypeArgument(tp)
+              }
             }
           }
         }

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -161,7 +161,7 @@ export default class JavascriptLexer extends BaseLexer {
         return null
       }
 
-      if (this.parseGenerics) {
+      if (this.parseGenerics && node.typeArguments) {
         let typeArgument = node.typeArguments.shift()
 
         const parseTypeArgument = (typeArg) => {
@@ -184,9 +184,9 @@ export default class JavascriptLexer extends BaseLexer {
             }
           }
         }
-      }
 
-      parseTypeArgument(typeArgument)
+        parseTypeArgument(typeArgument)
+      }
 
       let optionsArgument = node.arguments.shift()
 

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -323,4 +323,45 @@ describe('JavascriptLexer', () => {
 
     assert.equal(warningCount, 1)
   })
+
+  it('extracts count options', () => {
+    const Lexer = new JavascriptLexer({ typeMap: { CountType: { count: '' } } })
+
+    const content = 'i18n.t<{count: number}>("key_count");'
+    assert.deepEqual(Lexer.extract(content, 'file.ts'), [
+      {
+        key: 'key_count',
+        count: '',
+      },
+    ])
+
+    const content2 = `type CountType = {count : number};
+  i18n.t<CountType>("key_count");`
+    assert.deepEqual(Lexer.extract(content2, 'file.ts'), [
+      {
+        count: '',
+        key: 'key_count',
+      },
+    ])
+
+    const content3 = `type CountType = {count : number};
+     i18n.t<CountType & {my_custom: number}>("key_count");`
+    assert.deepEqual(Lexer.extract(content3, 'file.ts'), [
+      {
+        key: 'key_count',
+        count: '',
+        my_custom: '',
+      },
+    ])
+
+    const content4 = `type CountType = {count : number};
+     i18n.t<CountType | {my_custom: number}>("key_count");`
+    assert.deepEqual(Lexer.extract(content4, 'file.ts'), [
+      {
+        key: 'key_count',
+        count: '',
+        my_custom: '',
+      },
+    ])
+  })
 })

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -325,7 +325,10 @@ describe('JavascriptLexer', () => {
   })
 
   it('extracts count options', () => {
-    const Lexer = new JavascriptLexer({ typeMap: { CountType: { count: '' } } })
+    const Lexer = new JavascriptLexer({
+      typeMap: { CountType: { count: '' } },
+      parseGenerics: true,
+    })
 
     const content = 'i18n.t<{count: number}>("key_count");'
     assert.deepEqual(Lexer.extract(content, 'file.ts'), [


### PR DESCRIPTION
### Why am I submitting this PR

To be able to parse type data from typescript generics to generate "richer" keys

### Does it fix an existing ticket?

Yes : #454

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
