### PR TITLE
add i18nextOptions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,16 @@ module.exports = {
   //   description: "${maxLength}", // t('my-key', {maxLength: 150})
   // }
 
-  resetDefaultValueLocale: null
+  resetDefaultValueLocale: null,
   // The locale to compare with default values to determine whether a default value has been changed.
   // If this is set and a default value differs from a translation in the specified locale, all entries
   // for that key across locales are reset to the default value, and existing translations are moved to
   // the `_old` file.
+
+  i18nextOptions: null
+  // If you wish to customize options in internally used i18next instance, you can define an object with any 
+  // configuration property supported by i18next (https://www.i18next.com/overview/configuration-options).
+  // { compatibilityJSON: 'v3' } can be used to generate v3 compatible plurals.
 }
 ```
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -43,6 +43,12 @@ export default class i18nTransform extends Transform {
     }
 
     this.options = { ...this.defaults, ...options }
+    this.options.i18nextOptions = {
+      ...options.i18nextOptions,
+      pluralSeparator: this.options.pluralSeparator,
+      nsSeparator: this.options.namespaceSeparator
+    }
+
     if (this.options.keySeparator === false) {
       this.options.keySeparator = '__!NO_KEY_SEPARATOR!__'
     }
@@ -60,9 +66,8 @@ export default class i18nTransform extends Transform {
     this.localeRegex = /\$LOCALE/g
     this.namespaceRegex = /\$NAMESPACE/g
 
-    i18next.init({
-      pluralSeparator: this.options.pluralSeparator,
-    })
+    this.i18next = i18next.createInstance()
+    this.i18next.init(this.options.i18nextOptions)
   }
 
   error(error) {
@@ -174,7 +179,7 @@ export default class i18nTransform extends Transform {
       // generates plurals according to i18next rules: key_zero, key_one, key_two, key_few, key_many and key_other
       for (const entry of this.entries) {
         if (entry.count !== undefined) {
-          i18next.services.pluralResolver
+          this.i18next.services.pluralResolver
             .getSuffixes(locale, { ordinal: entry.ordinal })
             .forEach((suffix) => {
               transformEntry(entry, suffix)

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1380,6 +1380,60 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    it('generates plurals according to compatibilityJSON value', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({
+        i18nextOptions: { compatibilityJSON: 'v3' }
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('test {{count}}', { count: 1 })"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(enLibraryPath)) {
+          result = JSON.parse(file.contents)
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.deepEqual(result, {
+          'test {{count}}': '',
+          'test {{count}}_plural': '',
+        })
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
+    it('generates plurals according to compatibilityJSON value for languages with multiple plural forms', (done) => {
+      let result
+      const i18nextParser = new i18nTransform({ locales: ['ar'], i18nextOptions: { compatibilityJSON: 'v3'} })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('test {{count}}', { count: 1 })"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(arLibraryPath)) {
+          result = JSON.parse(file.contents)
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.deepEqual(result, {
+          'test {{count}}_0': '',
+          'test {{count}}_1': '',
+          'test {{count}}_2': '',
+          'test {{count}}_3': '',
+          'test {{count}}_4': '',
+          'test {{count}}_5': '',
+        })
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     it('generates one plural key for unknow languages', (done) => {
       let result
       const i18nextParser = new i18nTransform({ locales: ['unknown'] })


### PR DESCRIPTION
### Why am I submitting this PR

I need to generate v3 plurals for now. This pull request bring `i18nextOptions` property to customize i18next instance used internally to generate plurals.

This allow to add any i18next configuration property, like `compatibilityJSON: 'v3'`

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
