### PR TITLE
Add `fail-on-update` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Multiple globbing patterns are supported to specify complex file selections. You
 - **-o, --output <path>**: Path to the output directory (default: locales/$LOCALE/$NAMESPACE.json).
 - **-s, --silent**: Disable logging to stdout.
 - **--fail-on-warnings**: Exit with an exit code of 1 on warnings
+- **--fail-on-update**: Exit with an exit code of 1 when translations are updated (for CI purpose)
 
 ### Gulp
 
@@ -195,6 +196,9 @@ module.exports = {
 
   failOnWarnings: false,
   // Exit with an exit code of 1 on warnings
+
+  failOnUpdate: false,
+  // Exit with an exit code of 1 when translations are updated (for CI purpose)
 
   customValueTemplate: null
   // If you wish to customize the value output the value as an object, you can set your own format.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,7 @@ program
 .option('-o, --output <path>', 'Path to the output directory (default: locales/$LOCALE/$NAMESPACE.json)')
 .option('-s, --silent', 'Disable logging to stdout')
 .option('--fail-on-warnings', 'Exit with an exit code of 1 on warnings')
+.option('--fail-on-update', 'Exit with an exit code of 1 when translations are updated (for CI purpose)')
 
 program.on('--help', function() {
   console.log('  Examples:')
@@ -41,6 +42,7 @@ try {
 
 config.output = program.opts().output || config.output || 'locales/$LOCALE/$NAMESPACE.json'
 config.failOnWarnings = program.opts().failOnWarnings || config.failOnWarnings || false
+config.failOnUpdate = program.opts().failOnUpdate || config.failOnUpdate || false
 
 var args = program.args || []
 var globs

--- a/src/transform.js
+++ b/src/transform.js
@@ -51,6 +51,7 @@ export default class i18nTransform extends Transform {
     this.entries = []
 
     this.parserHadWarnings = false
+    this.parserHadUpdate = false
     this.parser = new Parser(this.options)
     this.parser.on('error', (error) => this.error(error))
     this.parser.on('warning', (warning) => this.warn(warning))
@@ -221,6 +222,14 @@ export default class i18nTransform extends Transform {
           console.log()
         }
 
+        if (this.options.failOnUpdate) {
+          const addCount = countWithPlurals - mergeCount
+          if (addCount + restoreCount + oldCount !== 0) {
+            this.parserHadUpdate = true
+            continue
+          }
+        }
+
         if (this.options.failOnWarnings && this.parserHadWarnings) {
           continue
         }
@@ -252,6 +261,14 @@ export default class i18nTransform extends Transform {
       this.emit(
         'error',
         'Warnings were triggered and failOnWarnings option is enabled. Exiting...'
+      )
+      process.exit(1)
+    }
+
+    if (this.options.failOnUpdate && this.parserHadUpdate) {
+      this.emit(
+        'error',
+        'Some translations was updated and failOnUpdate option is enabled. Exiting...'
       )
       process.exit(1)
     }

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -98,4 +98,16 @@ describe('CLI', function () {
 
     assert.include(subprocess.stdout, '0 files were parsed')
   })
+
+  it('works with `--fail-on-update` option', async () => {
+    try {
+      await execa.command('yarn test:cli --fail-on-update')
+    } catch (error) {
+      assert.strictEqual(error.exitCode, 1)
+      assert.include(
+        error.stdout.replace(),
+        'Some translations was updated and failOnUpdate option is enabled. Exiting...'
+      )
+    }
+  })
 })


### PR DESCRIPTION
### Why am I submitting this PR

To be able to check if somebody forgot to extract the translations on CI, we need a way to check if everything is up-to-date.

This `fail-on-update` option solve this issue, exiting with code 1 if something was generated.

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
