### PR TITLE
Fix trans parsing of spaces

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -134,6 +134,20 @@ export default class JsxLexer extends JavascriptLexer {
   nodeToString(node, sourceText) {
     const children = this.parseChildren.call(this, node.children, sourceText)
 
+    const flattenText = (children) =>
+      children
+        .reduce((res, c) => {
+          const last = res[0]
+          if (last?.type == 'text' && c.type == 'text') {
+            const newContent = last.content + c.content
+            last.content = newContent
+
+            return res
+          }
+          return [c].concat(res)
+        }, [])
+        .reverse()
+
     const elemsToString = (children) =>
       children
         .map((child, index) => {
@@ -157,7 +171,7 @@ export default class JsxLexer extends JavascriptLexer {
         })
         .join('')
 
-    return elemsToString(children)
+    return elemsToString(flattenText(children))
   }
 
   parseChildren(children = [], sourceText) {

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -350,6 +350,13 @@ describe('JsxLexer', () => {
         )
         done()
       })
+
+      it('handles tags after spaces correctly', (done) => {
+        const Lexer = new JsxLexer({ transSupportBasicHtmlNodes: true })
+        const content = '<Trans>a{" "}<a>b</a></Trans>'
+        assert.equal(Lexer.extract(content)[0].defaultValue, 'a <1>b</1>')
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
### Why am I submitting this PR

Adding a `{" "}` is a common pattern when a string is broken into
multiple lines (for example by prettier). But having that extra string
in the component caused the lexer to return the wrong identifier for
following tags leading to i18next (20.6.1) not displaying the string correctly.

There are other ways of solving this and I'm not sure if this way is the best, happy to change to another fix if requested!

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
