### PR TITLE
Set custom namespace functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ The default configuration is below:
   js: [{
     lexer: 'JavascriptLexer',
     functions: ['t'], // Array of functions to match
+    functionsNamespace: ['useTranslation', 'withTranslation'], // Array of functions to match for namespace
   }],
 }
 ```

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -7,6 +7,7 @@ export default class JavascriptLexer extends BaseLexer {
 
     this.callPattern = '(?<=^|\\s|\\.)' + this.functionPattern() + '\\(.*\\)'
     this.functions = options.functions || ['t']
+    this.namespaceFunctions = options.namespaceFunctions || ['useTranslation', 'withTranslation']
     this.attr = options.attr || 'i18nKey'
     this.parseGenerics = options.parseGenerics || false
     this.typeMap = options.typeMap || {}
@@ -111,9 +112,7 @@ export default class JavascriptLexer extends BaseLexer {
   expressionExtractor(node) {
     const entry = {}
 
-    if (
-      (node.expression.escapedText === 'useTranslation' ||
-        node.expression.escapedText === 'withTranslation') &&
+    if (this.namespaceFunctions.inlcudes(node.expression.escapedText) &&
       node.arguments.length
     ) {
       const { text, elements } = node.arguments[0]

--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -7,7 +7,10 @@ export default class JavascriptLexer extends BaseLexer {
 
     this.callPattern = '(?<=^|\\s|\\.)' + this.functionPattern() + '\\(.*\\)'
     this.functions = options.functions || ['t']
-    this.namespaceFunctions = options.namespaceFunctions || ['useTranslation', 'withTranslation']
+    this.namespaceFunctions = options.namespaceFunctions || [
+      'useTranslation',
+      'withTranslation',
+    ]
     this.attr = options.attr || 'i18nKey'
     this.parseGenerics = options.parseGenerics || false
     this.typeMap = options.typeMap || {}
@@ -112,7 +115,8 @@ export default class JavascriptLexer extends BaseLexer {
   expressionExtractor(node) {
     const entry = {}
 
-    if (this.namespaceFunctions.inlcudes(node.expression.escapedText) &&
+    if (
+      this.namespaceFunctions.includes(node.expression.escapedText) &&
       node.arguments.length
     ) {
       const { text, elements } = node.arguments[0]

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -215,6 +215,16 @@ describe('JavascriptLexer', () => {
         { namespace: 'baz', key: 'bar', ns: 'baz' },
       ])
     })
+
+    it('extracts namespace with a custom hook', () => {
+      const Lexer = new JavascriptLexer({
+        namespaceFunctions: ['useCustomTranslationHook'],
+      })
+      const content = 'const {t} = useCustomTranslationHook("foo"); t("bar");'
+      assert.deepEqual(Lexer.extract(content), [
+        { namespace: 'foo', key: 'bar' },
+      ])
+    })
   })
 
   describe('withTranslation', () => {


### PR DESCRIPTION
When you need to use a custom hook for translations

### Why am I submitting this PR

I'm using a custom hook and unable to extract namespaces without writing a custom lexer

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
