### PR TITLE
Fixing false key detection with the key attribute in jsx

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -13,7 +13,7 @@ export default class JsxLexer extends JavascriptLexer {
       'i',
       'p',
     ]
-    this.omitAttributes = [this.attr, 'ns', 'defaults']
+    this.omitAttributes = [this.attr, 'ns', 'defaults', 'key']
   }
 
   extract(content, filename = '__default.jsx') {

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -221,6 +221,15 @@ describe('JsxLexer', () => {
       ])
       done()
     })
+
+    it("doesn't add a key for the 'key' attribute", (done) => {
+      const Lexer = new JsxLexer()
+
+      const emptyTag = `<Trans key={'foo'}></Trans>`
+      assert.deepEqual(Lexer.extract(emptyTag), [])
+
+      done()
+    })
   })
 
   describe('supports TypeScript', () => {


### PR DESCRIPTION
### Why am I submitting this PR

Currently, if the Trans component has the attribute ```key```, it causes an override of the ```i18nKey``` attribute and in the further process a wrong translation key would be exported.

The ```key``` attribute is however sometimes added, if the Trans component is used for example in a loop.

For example:

```jsx
<Trans key={index} i18nKey={'foo'}/>
```

Would export
```
"{index}": ""
```

This is caused by the jsx-lexer storing the value of the ```i18nKey``` as ```key``` and later copying other attributes into the same object. Therefore the ```key``` attribute overrides the ```i18nKey``` attribute

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
