### PR TITLE
Use pathToFileURL for import

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { pathToFileURL } from 'url'
 import { promises as fsp } from 'fs'
 import colors from 'colors'
 import path from 'path'
@@ -48,7 +49,8 @@ import i18nTransform from '../dist/transform.js'
 
   let config = {}
   try {
-    config = (await import(path.resolve(program.opts().config))).default
+    config = (await import(pathToFileURL(path.resolve(program.opts().config))))
+      .default
   } catch (err) {
     if (err.code === 'MODULE_NOT_FOUND') {
       console.log(


### PR DESCRIPTION
Fixes broken import on Windows in 6.0.0.

### Why am I submitting this PR

To fix issue described in #527 

### Does it fix an existing ticket?

Yes #527

### Checklist

- [x] only relevant code is changed
- [x] tests are included and pass: `yarn test` (No changes necessary)
- [x] documentation is changed or added (No changes necessary)
