### PR TITLE
fix: count keys for each namespace instead of global

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -755,6 +755,35 @@ describe('parser', () => {
         console.log.restore()
       })
 
+      it('logs number of unique keys', (done) => {
+        const i18nextParser = new i18nTransform({
+          verbose: true,
+          output: 'test/locales/$LOCALE/$NAMESPACE.json',
+          locales: ['en'],
+        })
+        const fakeFile = new Vinyl({
+          contents: Buffer.from(
+            `t('key', {
+              ns: 'namespace1',
+            })
+            t('key', {
+              ns: 'namespace2',
+            })
+            `
+          ),
+          path: 'file.js',
+        })
+
+        i18nextParser.on('data', () => {})
+
+        i18nextParser.once('end', () => {
+          assert(console.log.calledWith('Unique keys: 1 (1 with plurals)'))
+          done()
+        })
+
+        i18nextParser.end(fakeFile)
+      })
+
       describe('with defaultResetLocale', () => {
         it('logs the number of values reset', (done) => {
           const i18nextParser = new i18nTransform({


### PR DESCRIPTION
### Why am I submitting this PR

When using the verbose option, keys are counted globally while presented as if it is per file. This merge request make sure that statistics are given for each namespace

### Does it fix an existing ticket?

Yes,
As a side effect of the incorrect count for the number of unique/plural keys the fail-on-update bug as described in #489 is not working correctly. This should now be fixed too.

### Checklist

- [x ] only relevant code is changed (make a diff before you submit the PR)
- [ x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ x] documentation is changed or added
