### PR TITLE
Fix: run all test instead of single one

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -328,7 +328,7 @@ describe('parser', () => {
     i18nextParser.end(fakeFile)
   })
 
-  it.only('does not overwrite the namespace file if it already exists', (done) => {
+  it('does not overwrite the namespace file if it already exists', (done) => {
     let resultContent
     const i18nextParser = new i18nTransform({
       locales: ['en'],


### PR DESCRIPTION
### Why am I submitting this PR

Test suite is adapted to run only a single test. Removing .only with make sure all test runs on `yarn test`
### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
