### PR TITLE
Updated exports to fix pod install in RN

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "type": "module",
   "license": "MIT",
   "author": "Karel Ledru",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "i18next": "./bin/cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Karel Ledru",
   "exports": {
     ".": {
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
### Why am I submitting this PR

To fix an issue with React Native pod install failing because `package.json` is not included as an export  in `package.json`  
([see node package exports reference](https://nodejs.org/api/packages.html#exports))

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
