### PR TITLE
update example with correct lexer config variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The default configuration is below:
   js: [{
     lexer: 'JavascriptLexer',
     functions: ['t'], // Array of functions to match
-    functionsNamespace: ['useTranslation', 'withTranslation'], // Array of functions to match for namespace
+    namespaceFunctions: ['useTranslation', 'withTranslation'], // Array of functions to match for namespace
   }],
 }
 ```


### PR DESCRIPTION
https://github.com/i18next/i18next-parser/blob/master/src/lexers/javascript-lexer.js#L10

### Why am I submitting this PR

The name of the lexer config variable does not match with the case in the code base. I fixed that.
See [here](https://github.com/i18next/i18next-parser/blob/master/src/lexers/javascript-lexer.js#L10) for the usage in code.

### Does it fix an existing ticket?

No

### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
