### PR TITLE
Fix self-closing tag to match with react-i18next

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -170,7 +170,7 @@ export default class JsxLexer extends JavascriptLexer {
               const childrenString = elemsToString(child.children)
               return childrenString || !(useTagName && child.selfClosing)
                 ? `<${elementName}>${childrenString}</${elementName}>`
-                : `<${elementName} />`
+                : `<${elementName}/>`
             default:
               throw new Error('Unknown parsed content: ' + child.type)
           }

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -366,7 +366,7 @@ describe('JsxLexer', () => {
       it('keeps self-closing tags untouched when transSupportBasicHtmlNodes is true', (done) => {
         const Lexer = new JsxLexer({ transSupportBasicHtmlNodes: true })
         const content = '<Trans>a<br />b</Trans>'
-        assert.equal(Lexer.extract(content)[0].defaultValue, 'a<br />b')
+        assert.equal(Lexer.extract(content)[0].defaultValue, 'a<br/>b')
         done()
       })
 


### PR DESCRIPTION
### Why am I submitting this PR

This PR corrects the behavior of `<br />` to match with [react-i18next's nodeToString routine](https://github.com/i18next/react-i18next/blob/master/src/Trans.js#L59).

When `transSupportBasicHtmlNodes` is true, inside `<Trans>`, react-i18next converts `<br />` into `<br/>`. But i18next-parser converts `<br />` into `<br />`, causing a difference between the defaultValue generated with each other.

If `i18nKey` is specified, this wouldn't cause any problem because only `defaultValue` would differ, and both `<br/>` and `<br />` can be parsed well by react-i18next.

However, if only `defaultValue` is specified, the defaultValue will be used as the i18nKey. Therefore it makes generated key and the actual key to mismatch, making react-i18next unable to find the translation entry.

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added

FYI) I've encountered a failing test while running tests. I investigated the problem, and it turned out that `Intl.PluralRules` defaults to the system language if an unknown locale is specified - so the test will fail if the system language is set to other languages that have more/less than 2 plural types.

(`Intl.PluralRules` is used by [i18next.PluralResolver](https://github.com/i18next/i18next/blob/master/src/PluralResolver.js).)

The test can be successfully run by changing the system language to en-US:
```
LANG='en-US' yarn test
```

```
  1) parser
       options
         generates one plural key for unknow languages:

      Uncaught AssertionError: expected { 'test {{count}}_other': '' } to deeply equal { 'test {{count}}_one': '', …(1) }
      + expected - actual

       {
      +  "test {{count}}_one": ""
         "test {{count}}_other": ""
       }
```
