### PR TITLE
Make defaultValue take precedence over useKeysAsDefaultValue if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ export default {
 
   useKeysAsDefaultValue: false,
   // Whether to use the keys as the default value; ex. "Hello": "Hello", "World": "World"
-  // This option takes precedence over the `defaultValue` and `skipDefaultValues` options
+  // Will only take effect if `defaultValue` is not present or `skipDefaultValues` is true
   // You may also specify a function accepting the locale and namespace as arguments
 
   verbose: false,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -59,7 +59,7 @@ function dotPathToHash(entry, target = {}, options = {}) {
     newValue = ''
   }
 
-  if (useKeysAsDefaultValue) {
+  if (useKeysAsDefaultValue && newValue === '') {
     newValue = key
   }
 

--- a/test/helpers/dotPathToHash.test.js
+++ b/test/helpers/dotPathToHash.test.js
@@ -75,6 +75,16 @@ describe('dotPathToHash helper function', () => {
     done()
   })
 
+  it('handles a `defaultValue` option when `useKeysAsDefaultValue` is true', (done) => {
+    const { target } = dotPathToHash(
+      { keyWithNamespace: 'one' },
+      {},
+      { value: 'myDefaultValue', useKeysAsDefaultValue: true }
+    )
+    assert.deepEqual(target, { one: 'myDefaultValue' })
+    done()
+  })
+
   it('handles a `separator` option', (done) => {
     const { target } = dotPathToHash(
       { keyWithNamespace: 'one_two_three.' },


### PR DESCRIPTION
### Why am I submitting this PR

When useKeysAsDefaultValue=true, only apply the replacement if no defaultValue is specified.

### Does it fix an existing ticket?

Yes #671 

### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
