### PR TITLE
feat: add config option to disable the non-printable utf8 escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ export default {
   // {
   //   lineWidth: -1,
   // }
+
+
+  escapeNonPrintableUnicodeCharacters: true
+  // If you do not want the parser to convert non printable characters to UTF-8 Character Sequences (ex : \\u00a0), put this to true.
 }
 ```
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -42,6 +42,7 @@ export default class i18nTransform extends Transform {
       customValueTemplate: null,
       failOnWarnings: false,
       yamlOptions: null,
+      escapeNonPrintableUnicodeCharacters: true
     }
 
     this.options = { ...this.defaults, ...options }
@@ -370,12 +371,15 @@ export default class i18nTransform extends Transform {
       })
     } else {
       text = JSON.stringify(contents, null, this.options.indentation) + '\n'
-      // Convert non-printable Unicode characters to unicode escape sequence
-      // https://unicode.org/reports/tr18/#General_Category_Property
-      text = text.replace(/[\p{Z}\p{Cc}\p{Cf}]/gu, (chr) => {
-        const n = chr.charCodeAt(0)
-        return n < 128 ? chr : `\\u${`0000${n.toString(16)}`.substr(-4)}`
-      })
+
+      if(this.options.escapeNonPrintableUnicodeCharacters){
+        // Convert non-printable Unicode characters to unicode escape sequence
+        // https://unicode.org/reports/tr18/#General_Category_Property
+        text = text.replace(/[\p{Z}\p{Cc}\p{Cf}]/gu, (chr) => {
+          const n = chr.charCodeAt(0)
+          return n < 128 ? chr : `\\u${`0000${n.toString(16)}`.substr(-4)}`
+        })
+      }
     }
 
     if (this.options.lineEnding === 'auto') {


### PR DESCRIPTION
### Why am I submitting this PR

In my project, when I run i18next-parser, I get the converted entities, however, my automated translation tool converts them back to the non-escaped sequence. 

This has become a little dance where as soon as I merge the translations I get another PR from the service to change it back.

### Does it fix an existing ticket?

Yes/No #000

### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
