### PR TITLE
copy typescript type definition file to the dist folder after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:cli": "yarn -s build && ./bin/cli.js '**/*.html' -o 'test/manual/$LOCALE/$NAMESPACE.json' && ./bin/cli.js -c test/cli/i18next-parser.config.js && ./bin/cli.js -c test/cli/i18next-parser.config.ts && ./bin/cli.js -c test/cli/i18next-parser.config.yaml",
     "watch": "babel src -d dist -w",
     "prettify": "prettier --write \"{src,test}/**/*.js\"",
-    "build": "babel src -d dist",
+    "build": "babel src -d dist&&cp index.d.ts dist",
     "prepare": "husky install",
     "prepublishOnly": "yarn -s prettify && yarn -s build"
   },


### PR DESCRIPTION
### Why am I submitting this PR

This resolves missing typescript definition file in the production build.

### Does it fix an existing ticket?

Yes #694 
