### PR TITLE
feat: parse namespace from `t` type arguments

### DIFF
--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -114,7 +114,7 @@ export default class JavascriptLexer extends BaseLexer {
         (param) =>
           param.name &&
           param.name.kind === ts.SyntaxKind.Identifier &&
-          param.name.text === 't'
+          this.functions.includes(param.name.text)
       )
 
     if (
@@ -124,7 +124,7 @@ export default class JavascriptLexer extends BaseLexer {
     ) {
       const { typeArguments } = tFunctionParam.type
       if (
-        typeArguments.length === 1 &&
+        typeArguments.length &&
         typeArguments[0].kind === ts.SyntaxKind.LiteralType
       ) {
         this.defaultNamespace = typeArguments[0].literal.text

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -128,6 +128,17 @@ describe('JavascriptLexer', () => {
     done()
   })
 
+  it('parses namespace from `t` type argument', (done) => {
+    const Lexer = new JavascriptLexer()
+    const content = `
+      const content = (t: TFunction<"foo">) => ({
+        title: t("bar"),
+      })
+    `
+    assert.deepEqual(Lexer.extract(content), [{ key: 'bar', namespace: 'foo' }])
+    done()
+  })
+
   it("does not parse text with `doesn't` or isolated `t` in it", (done) => {
     const Lexer = new JavascriptLexer()
     const js =


### PR DESCRIPTION
### Why am I submitting this PR

It allows us to use type argument of `t` function (see [type definition](https://github.com/i18next/i18next/blob/master/index.d.ts#L881)) to set default namespace when parsing content.

This is particularly useful when you are passing `t` from component, for example

```
// component.tsx
export const UserDetail = () => {
  const { t } = useTranslation("user");
  const templateData = useMemo(() => getData(t), [t]);
  return <UserProfile help={t("help.tooltip")} content={templateData} />
};

// util.ts
export const getData = (t: TFunction<"user">) => ({
  greeting: t("user.greeting", "Welcome!"),
  intro: t("user.body"),
})
```

Even though the example above might not be the best use case, it should be good enough to explain how we can benefit from this.

In the case above, you'd normally end up with one translation in `user` namespace and the rest in the default namespace.
With the proposed changes, we would parse the function declarations to extract namespace from type arguments of `t` so that all parsed keys end up in `user` namespace.

What do you guys think about this? Would it be somewhat helpful? Have you found yourselves dealing with this kind of cases in the past?

### Does it fix an existing ticket?

Yes #703

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
