### PR TITLE
restore .mjs as a config file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Multiple globbing patterns are supported to specify complex file selections. You
 
 **IMPORTANT NOTE**: If you pass the globs as CLI argument, they must be relative to where you run the command (aka relative to `process.cwd()`). If you pass the globs via the `input` option of the config file, they must be relative to the config file.
 
-- **-c, --config <path>**: Path to the config file (default: i18next-parser.config.{js,json,ts,yaml,yml}).
+- **-c, --config <path>**: Path to the config file (default: i18next-parser.config.{js,mjs,json,ts,yaml,yml}).
 - **-o, --output <path>**: Path to the output directory (default: locales/$LOCALE/$NAMESPACE.json).
 - **-s, --silent**: Disable logging to stdout.
 - **--fail-on-warnings**: Exit with an exit code of 1 on warnings
@@ -93,17 +93,17 @@ npm install --save-dev i18next-parser
 
 ```javascript
 import Funnel from 'broccoli-funnel'
-import { broccoli as i18nextParser} from 'i18next-parser'
+import { broccoli as i18nextParser } from 'i18next-parser'
 
 const appRoot = 'broccoli'
 
 let i18n = new Funnel(appRoot, {
   files: ['handlebars.hbs', 'javascript.js'],
-  annotation: 'i18next-parser'
+  annotation: 'i18next-parser',
 })
 
 i18n = new i18nextParser([i18n], {
-  output: 'broccoli/locales/$LOCALE/$NAMESPACE.json'
+  output: 'broccoli/locales/$LOCALE/$NAMESPACE.json',
 })
 
 export default i18n

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -55,6 +55,7 @@ import i18nTransform from '../dist/transform.js'
     const lilconfigOptions = {
       searchPlaces: [
         `${pkg.name}.config.js`,
+        `${pkg.name}.config.mjs`,
         `${pkg.name}.config.json`,
         `${pkg.name}.config.ts`,
         `${pkg.name}.config.yaml`,
@@ -62,6 +63,7 @@ import i18nTransform from '../dist/transform.js'
       ],
       loaders: {
         '.js': esConfigLoader,
+        '.mjs': esConfigLoader,
         '.ts': tsConfigLoader,
         '.yaml': yamlConfigLoader,
         '.yml': yamlConfigLoader,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,7 +22,7 @@ import i18nTransform from '../dist/transform.js'
     .version(pkg.version)
     .option(
       '-c, --config <path>',
-      'Path to the config file (default: i18next-parser.config.{js,json,ts,yaml,yml})'
+      'Path to the config file (default: i18next-parser.config.{js,mjs,json,ts,yaml,yml})'
     )
     .option(
       '-o, --output <path>',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "coverage": "c8 --all --include='src/**/*[.js|.jsx|.ts|.tsx]' --reporter=lcov --reporter=text yarn test",
     "test": "mocha -r @babel/register -r @babel/polyfill --recursive test/*.test.js test/**/*.test.js",
-    "test:cli": "yarn -s build && ./bin/cli.js '**/*.html' -o 'test/manual/$LOCALE/$NAMESPACE.json' && ./bin/cli.js -c test/cli/i18next-parser.config.js && ./bin/cli.js -c test/cli/i18next-parser.config.ts && ./bin/cli.js -c test/cli/i18next-parser.config.yaml",
+    "test:cli": "yarn -s build && ./bin/cli.js '**/*.html' -o 'test/manual/$LOCALE/$NAMESPACE.json' && ./bin/cli.js -c test/cli/i18next-parser.config.js && ./bin/cli.js -c test/cli/i18next-parser.config.mjs && ./bin/cli.js -c test/cli/i18next-parser.config.ts && ./bin/cli.js -c test/cli/i18next-parser.config.yaml",
     "watch": "babel src -d dist -w",
     "prettify": "prettier --write \"{src,test}/**/*.js\"",
     "build": "babel src -d dist",

--- a/test/cli/i18next-parser.config.mjs
+++ b/test/cli/i18next-parser.config.mjs
@@ -1,0 +1,10 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export default {
+  input: ['**/*.html'],
+  output: path.resolve(__dirname, 'locales/$LOCALE/$NAMESPACE.json'),
+  sort: true,
+}


### PR DESCRIPTION
### Why am I submitting this PR

Our projects are using .mjs as the config file extension and this stopped working since version 7 of parser. 

### Does it fix an existing ticket?

Yes/No #708 

### Checklist

- [ X] only relevant code is changed (make a diff before you submit the PR)
- [ X] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ X] documentation is changed or added
