### PR TITLE
Fix esm import in cjs project

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -271,7 +271,7 @@ async function esConfigLoader(filepath) {
 }
 
 async function tsConfigLoader(filepath) {
-  const outfile = filepath + '.bundle.js'
+  const outfile = filepath + '.bundle.mjs'
   await build({
     absWorkingDir: process.cwd(),
     entryPoints: [filepath],


### PR DESCRIPTION
### Why am I submitting this PR

`i18next-parser.config.ts` is compiled into ESM before loading.

However, the compiled tmp file has extension `.js`. In a CJS project without `type: module`, it will fail to load.

This PR change tmp file extesion to `.mjs`. So Node.js always load it as ESM.

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
