### PR TITLE
add support for user-defined component functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Default configuration:
   jsx: [{
     lexer: 'JsxLexer',
     attr: 'i18nKey', // Attribute for the keys
+    componentFunctions: ['Trans'], // Array of components to match
   }],
 }
 ```

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -6,6 +6,7 @@ export default class JsxLexer extends JavascriptLexer {
   constructor(options = {}) {
     super(options)
 
+    this.componentFunctions = options.componentFunctions || ['Trans']
     this.transSupportBasicHtmlNodes =
       options.transSupportBasicHtmlNodes || false
     this.transKeepBasicHtmlNodesFor = options.transKeepBasicHtmlNodesFor || [
@@ -88,7 +89,7 @@ export default class JsxLexer extends JavascriptLexer {
 
     const getKey = (node) => getPropValue(node, this.attr)
 
-    if (tagNode.tagName.text === 'Trans') {
+    if (this.componentFunctions.includes(tagNode.tagName.text)) {
       const entry = {}
       entry.key = getKey(tagNode)
 

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -132,6 +132,23 @@ describe('JsxLexer', () => {
       done()
     })
 
+    it('extracts keys from user-defined components', (done) => {
+      const Lexer = new JsxLexer({
+        componentFunctions: ['Translate', 'FooBar'],
+      })
+      const content = `<div>
+      <Translate i18nKey="something">Something to translate.</Translate>
+      <NotSupported i18nKey="jkl">asdf</NotSupported>
+      <FooBar i18nKey="asdf">Lorum Ipsum</FooBar>
+      </div>
+      `
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'something', defaultValue: 'Something to translate.' },
+        { key: 'asdf', defaultValue: 'Lorum Ipsum' },
+      ])
+      done()
+    })
+
     it('extracts keys from single line comments', (done) => {
       const Lexer = new JsxLexer()
       const content = `


### PR DESCRIPTION
### Why am I submitting this PR

To fix the issue describe in #803. This PR adds support for user-defined component functions to the JsxLexer.

### Does it fix an existing ticket?

Yes #803

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
