### PR TITLE
improve warning message when prop variables are detected

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -76,7 +76,7 @@ export default class JsxLexer extends JavascriptLexer {
       if (attribute.initializer.expression?.kind === ts.SyntaxKind.Identifier) {
         this.emit(
           'warning',
-          `Namespace is not a string literal: ${attribute.initializer.expression.text}`
+          `"${attributeName}" prop is not a string literal: ${attribute.initializer.expression.text}`
         )
         return undefined
       }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -2530,7 +2530,23 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
-    it('emits a `warning` event if a namespace contains a variable', (done) => {
+    it('emits a `warning` event if ns prop contains a variable', (done) => {
+      const i18nextParser = new i18nTransform({
+        output: 'test/locales/$LOCALE/$NAMESPACE.json',
+      })
+      const fakeFile = new Vinyl({
+        contents: Buffer.from('<Trans ns={variable} />'),
+        path: 'file.jsx',
+      })
+
+      i18nextParser.on('warning', (message) => {
+        assert.equal(message, '"ns" prop is not a string literal: variable')
+        done()
+      })
+      i18nextParser.end(fakeFile)
+    })
+
+    it('emits a `warning` event if a component prop contains a variable', (done) => {
       const i18nextParser = new i18nTransform({
         output: 'test/locales/$LOCALE/$NAMESPACE.json',
       })
@@ -2540,7 +2556,10 @@ describe('parser', () => {
       })
 
       i18nextParser.on('warning', (message) => {
-        assert.equal(message, 'Namespace is not a string literal: variable')
+        assert.equal(
+          message,
+          '"i18nKey" prop is not a string literal: variable'
+        )
         done()
       })
       i18nextParser.end(fakeFile)


### PR DESCRIPTION
### Why am I submitting this PR

The warning message when a component prop is assigned using a variable currently has a hardcoded value of `Namespace`, but this warning could be fired when any prop is extracted. This PR is to improve the warning message to indicate which prop is using a variable.

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
