### PR TITLE
Add support for string concatenation in default values

### DIFF
--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -256,13 +256,27 @@ export default class JavascriptLexer extends BaseLexer {
 
       let optionsArgument = node.arguments.shift()
 
-      // Second argument could be a string default value
+      // Second argument could be a (concatenated) string default value
       if (
         optionsArgument &&
         (optionsArgument.kind === ts.SyntaxKind.StringLiteral ||
           optionsArgument.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral)
       ) {
         entry.defaultValue = optionsArgument.text
+        optionsArgument = node.arguments.shift()
+      } else if (
+        optionsArgument &&
+        optionsArgument.kind === ts.SyntaxKind.BinaryExpression
+      ) {
+        const concatenatedString = this.concatenateString(optionsArgument)
+        if (!concatenatedString) {
+          this.emit(
+            'warning',
+            `Default value is not a string literal: ${optionsArgument.text}`
+          )
+          return null
+        }
+        entry.defaultValue = concatenatedString
         optionsArgument = node.arguments.shift()
       }
 

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -27,6 +27,15 @@ describe('JavascriptLexer', () => {
     done()
   })
 
+  it('extracts the second argument string concatenation as defaultValue', (done) => {
+    const Lexer = new JavascriptLexer()
+    const content = 'i18n.t("first", "bla" + "bla" + "bla")'
+    assert.deepEqual(Lexer.extract(content), [
+      { key: 'first', defaultValue: 'blablabla' },
+    ])
+    done()
+  })
+
   it('extracts the defaultValue/context options', (done) => {
     const Lexer = new JavascriptLexer()
     const content = 'i18n.t("first", {defaultValue: "foo", context: \'bar\'})'


### PR DESCRIPTION
### Why am I submitting this PR

When using a string as the second argument to the `t` function, it would be interpreted as `defaultValue` for that key. However, sometimes that string becomes too long and you need to split it into multiple lines. Using template literals has its downsides as it preserves indents and new lines. Thus, the easiest thing to do would be to use string concatenation, e.g.:
```js
i18next.t(
  'key',
  'This is a very long string that needs to be split into multiple ' +
  'lines bla bla bla bla bla bla bla bla bla'
)
```

### Does it fix an existing ticket?

Not that I'm aware of.

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
