### PR TITLE
feat: allow to disable plural handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ export default {
   pluralSeparator: '_',
   // Plural separator used in your translation keys
   // If you want to use plain english keys, separators such as `_` might conflict. You might want to set `pluralSeparator` to a different string that does not occur in your keys.
+  // If you don't want to generate keys for plurals (for example, in case you are using ICU format), set `pluralSeparator: false`.
 
   input: undefined,
   // An array of globs that describe where to look for source files

--- a/src/transform.js
+++ b/src/transform.js
@@ -191,7 +191,10 @@ export default class i18nTransform extends Transform {
 
       // generates plurals according to i18next rules: key_zero, key_one, key_two, key_few, key_many and key_other
       for (const entry of this.entries) {
-        if (entry.count !== undefined) {
+        if (
+          this.options.pluralSeparator !== false &&
+          entry.count !== undefined
+        ) {
           this.i18next.services.pluralResolver
             .getSuffixes(locale, { ordinal: entry.ordinal })
             .forEach((suffix) => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -652,6 +652,31 @@ describe('parser', () => {
     i18nextParser.end(fakeFile)
   })
 
+  it('ignores plural values in existing catalog if pluralSeparator set to false', (done) => {
+    let result
+    const i18nextParser = new i18nTransform({
+      pluralSeparator: false,
+    })
+    const fakeFile = new Vinyl({
+      contents: Buffer.from("t('test {{count}}', { count: 1 })"),
+      path: 'file.js',
+    })
+
+    i18nextParser.on('data', (file) => {
+      if (file.relative.endsWith(enLibraryPath)) {
+        result = JSON.parse(file.contents)
+      }
+    })
+    i18nextParser.once('end', () => {
+      assert.deepEqual(result, {
+        'test {{count}}': '',
+      })
+      done()
+    })
+
+    i18nextParser.end(fakeFile)
+  })
+
   it('retrieves plural values in existing catalog', (done) => {
     let result
     const i18nextParser = new i18nTransform({


### PR DESCRIPTION
### Why am I submitting this PR

Adds possibility to disable keys generation for plurals by setting `pluralSeparator: false`.

### Does it fix an existing ticket?

closes https://github.com/i18next/i18next-parser/issues/463

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
