### PR TITLE
Skip extracting dynamic children in Trans components

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -208,9 +208,14 @@ export default class JsxLexer extends JavascriptLexer {
           const element = child.openingElement || child
           const name = element.tagName.escapedText
           const isBasic = !element.attributes.properties.length
+          const hasDynamicChildren = element.attributes.properties.find(
+            (prop) => prop.name.escapedText === 'i18nIsDynamicList'
+          )
           return {
             type: 'tag',
-            children: this.parseChildren(child.children, sourceText),
+            children: hasDynamicChildren
+              ? []
+              : this.parseChildren(child.children, sourceText),
             name,
             isBasic,
             selfClosing: child.kind === ts.SyntaxKind.JsxSelfClosingElement,

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -218,6 +218,17 @@ describe('JsxLexer', () => {
       done()
     })
 
+    it('skips dynamic children', (done) => {
+      const Lexer = new JsxLexer()
+      const content =
+        '<Trans>My dogs are named: <ul i18nIsDynamicList>{["rupert", "max"].map(dog => (<li>{dog}</li>))}</ul></Trans>'
+      assert.equal(
+        Lexer.extract(content)[0].defaultValue,
+        'My dogs are named: <1></1>'
+      )
+      done()
+    })
+
     it('erases comment expressions', (done) => {
       const Lexer = new JsxLexer()
       const content = '<Trans>{/* some comment */}Some Content</Trans>'


### PR DESCRIPTION
### Why am I submitting this PR
While working on localizing our project, we found that components with the `i18nIsDynamicList` property weren't being extracted correctly. See https://react.i18next.com/latest/trans-component#using-with-lists-v10.5.0 for the documentation on this prop.

### Does it fix an existing ticket?
No.

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
