### PR TITLE
Allow ignoring typecheck-helper functions around Trans tag variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,37 @@ If your JSX files have `.js` extension (e.g. create-react-app projects) you shou
 }
 ```
 
+##### Supporting helper functions in Trans tags
+
+If you're working with i18next in Typescript, you might be using a helper function to make sure that objects in <Trans /> components pass the typechecker: e.g.,
+
+```tsx
+const SomeComponent = (props) => (
+  <Trans>
+    Visit
+    <Link to='/user/john'>{castAsString({ name: props.name })}'s profile</Link>
+    {/* Equivalent to, but resolves typechecker errors with */}
+    <Link to='/user/john'>{{ name: props.name }}'s profile</Link>
+  </Trans>
+)
+
+function castAsString(record: Record<string, unknown>): string {
+  return record as unknown as string
+}
+```
+
+In order for the parser to extract variables properly, you can add a list of
+such functions to the lexer options:
+
+```
+{
+  js: [{
+    lexer: 'JsxLexer',
+    transIdentityFunctionsToIgnore: ['castAsString']
+  }],
+}
+```
+
 #### Ts(x)
 
 Typescript is supported via Javascript and Jsx lexers. If you are using Javascript syntax (e.g. with React), follow the steps in Jsx section, otherwise Javascript section.

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,17 @@ export interface JsxWithTypesLexerConfig {
   transKeepBasicHtmlNodesFor?: string[];
   parseGenerics: true;
   typeMap: Record<string, unknown>;
+  /**
+   * Identity functions within trans that should be parsed for their
+   * first arguments. Used for making typecheckers happy in a safe way: e.g., if in your code, you use:
+   *
+   * ```
+   * <Trans>Hello {castToString({ name })}</Trans>
+   * ```
+   *
+   * you'd want to pass in `transIdentityFunctionsToIgnore: ['castToString']`
+   */
+  transIdentityFunctionsToIgnore?: string[];
 }
 
 export interface VueLexerConfig {

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -227,7 +227,7 @@ export default class JsxLexer extends JavascriptLexer {
           }
 
           // simplify trivial expressions, like TypeScript typecasts
-          if (child.expression.kind === ts.SyntaxKind.AsExpression) {
+          while (child.expression.kind === ts.SyntaxKind.AsExpression) {
             child = child.expression
           }
 

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -428,6 +428,14 @@ describe('JsxLexer', () => {
         done()
       })
 
+      it('supports multi-step casts', (done) => {
+        const Lexer = new JsxLexer()
+        const content =
+          '<Trans>Hi, {{ name: "John" } as unknown as string}</Trans>'
+        assert.equal(Lexer.extract(content)[0].defaultValue, 'Hi, {{name}}')
+        done()
+      })
+
       it('supports variables in identity functions', (done) => {
         const Lexer = new JsxLexer({
           transIdentityFunctionsToIgnore: ['funcCall'],

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -427,6 +427,27 @@ describe('JsxLexer', () => {
         )
         done()
       })
+
+      it('supports variables in identity functions', (done) => {
+        const Lexer = new JsxLexer({
+          transIdentityFunctionsToIgnore: ['funcCall'],
+        })
+        const content = '<Trans>Hi, {funcCall({ name: "John" })}</Trans>'
+        assert.equal(Lexer.extract(content)[0].defaultValue, 'Hi, {{name}}')
+        done()
+      })
+
+      it('leaves non-identify functions alone', (done) => {
+        const Lexer = new JsxLexer({
+          transIdentityFunctionsToIgnore: ['funcCall'],
+        })
+        const content = '<Trans>Hi, {anotherFuncCall({ name: "John" })}</Trans>'
+        assert.equal(
+          Lexer.extract(content)[0].defaultValue,
+          'Hi, {anotherFuncCall({ name: "John" })}'
+        )
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
### Why am I submitting this PR

Thanks again for maintaining this, @karellm!

This PR helps with extraction for React + Typescript + i18next projects that use a helper function to help with typechecking.

By default, for React with Typescript, components don't allow passing in objects as children. e.g., the below wouldn't typecheck:

```tsx
const SomeComponent = (props) => (
  <Trans>Hello <b>{{ name: props.name }}</b></Trans>
);
```

i18next added [a type option, `allowObjectInHTMLChildren`](https://www.i18next.com/overview/typescript#custom-type-options) that helps with HTML elements. However, this still doesn't work for non-HTML components: e.g., the following would still not pass the typechecker.

```tsx
const SomeComponent = (props) => (
  <Trans>Hello <Link to="/profile">{{ name: props.name }}</Link></Trans>
);
```

As a result, we (and some other teams we know) use either of the below methods:


```tsx
// Option 1: already supported
const SomeComponent = (props) => (
  <Trans>Hello <Link to="/profile">{{ name: props.name } as any}</Link></Trans>
);

// Option 2
const SomeComponent = (props) => (
  <Trans>Hello <Link to="/profile">{{ name: props.name } as unknown as string}</Link></Trans>
);

// Option 3: slightly nicer because we can use a lint rule
// to make sure that castAsString() only appears in <Trans>
const SomeComponent = (props) => (
  <Trans>Hello <Link to="/profile">{castAsString({ name: props.name })}</Link></Trans>
);

function castAsString(obj: Record<string, unknown>): string {
  return obj as unknown as string;
}
```

However, right now, i18next-parser would not pick up `{ name: props.name }` since it's in a function call or multiple levels of type-casts.

### Changes

- Allow passing in an option to the JSX Lexer, `transIdentityFunctionsToIgnore`, that specifies identity functions to "unwrap" before parsing a Trans object for strings
- Allow multiple levels of type-casting (if we're not using an `as any` cast) to be unwrapped

### Does it fix an existing ticket?

No, but is somewhat related to #603 

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [X] documentation is changed or added
