### PR TITLE
Fix extracting Trans component without key, but with default value

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -135,10 +135,9 @@ export default class JsxLexer extends JavascriptLexer {
         } else entry[property.name.text] = true
       })
 
+      const nodeAsString = this.nodeToString.call(this, node, sourceText)
       const defaultsProp = getPropValue(tagNode, 'defaults')
-      let defaultValue =
-        defaultsProp || this.nodeToString.call(this, node, sourceText)
-
+      let defaultValue = defaultsProp || nodeAsString
       if (entry.shouldUnescape === true) {
         defaultValue = unescape(defaultValue)
       }
@@ -147,7 +146,7 @@ export default class JsxLexer extends JavascriptLexer {
         entry.defaultValue = defaultValue
 
         if (!entry.key) {
-          entry.key = entry.defaultValue
+          entry.key = nodeAsString
         }
       }
 

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -123,6 +123,15 @@ describe('JsxLexer', () => {
       done()
     })
 
+    it('extracts keys from Trans elements without an i18nKey, but with a defaults prop', (done) => {
+      const Lexer = new JsxLexer()
+      const content = '<Trans defaults="Steve">{{ name }}</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: '{{name}}', defaultValue: 'Steve' },
+      ])
+      done()
+    })
+
     it('extracts keys from Trans elements and ignores values of expressions and spaces', (done) => {
       const Lexer = new JsxLexer()
       const content = '<Trans count={count}>{{ key: property }}</Trans>'


### PR DESCRIPTION
Hi again! Just wanted to thank you for maintaining this project, and for responding so quick to my other PRs.

### Why am I submitting this PR
This PR fixes a bug that causes us to extract the keys of Trans components with default values incorrectly.

Take the following example:
```ts
<Trans>
  {{ name }}
</Trans>
```

The above results in the key `{{name}}`, which is correct. However, if we add a default value, it causes us to extract the key incorrectly:
```ts
<Trans defaults="Steve">
  {{ name }}
</Trans>
```

The above results in a key of `Steve`, which isn't correct. The key shouldn't change when we provide a default value.

### Does it fix an existing ticket?
Possibly fixes #249, but I'm if this is the same issue that the user was describing.

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
