### PR TITLE
Emit warning on non-literal content inside of Trans

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -170,7 +170,6 @@ export default class JsxLexer extends JavascriptLexer {
       children
         .map((child, index) => {
           switch (child.type) {
-            case 'js':
             case 'text':
               return child.content
             case 'tag':
@@ -301,18 +300,20 @@ export default class JsxLexer extends JavascriptLexer {
               : nonFormatProperties[0].name.text
 
             return {
-              type: 'js',
+              type: 'text',
               content: `{{${value}}}`,
             }
           }
 
-          // slice on the expression so that we ignore comments around it
           return {
-            type: 'js',
-            content: `{${sourceText.slice(
-              child.expression.pos,
-              child.expression.end
-            )}}`,
+            type: 'tag',
+            children: [],
+            // set to `false` to match i18next's behavior (non-self closing, indexed instead of named)
+            isBasic: false,
+            // unused when `isBasic` is set to `false`
+            name: '',
+            // self-closing is only for named tags
+            selfClosing: false,
           }
         } else {
           throw new Error('Unknown ast element when parsing jsx: ' + child.kind)

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -170,6 +170,7 @@ export default class JsxLexer extends JavascriptLexer {
       children
         .map((child, index) => {
           switch (child.type) {
+            case 'js':
             case 'text':
               return child.content
             case 'tag':
@@ -300,22 +301,22 @@ export default class JsxLexer extends JavascriptLexer {
               : nonFormatProperties[0].name.text
 
             return {
-              type: 'text',
+              type: 'js',
               content: `{{${value}}}`,
             }
           }
 
-          this.emit(
-            'warning',
-            `Child is not literal: ${sourceText.slice(
-              child.expression.pos,
-              child.expression.end
-            )}`
+          // slice on the expression so that we ignore comments around it
+          const slicedExpression = sourceText.slice(
+            child.expression.pos,
+            child.expression.end
           )
 
+          this.emit('warning', `Child is not literal: ${slicedExpression}`)
+
           return {
-            type: 'text',
-            content: '',
+            type: 'js',
+            content: `{${slicedExpression}}`,
           }
         } else {
           throw new Error('Unknown ast element when parsing jsx: ' + child.kind)

--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -305,15 +305,17 @@ export default class JsxLexer extends JavascriptLexer {
             }
           }
 
+          this.emit(
+            'warning',
+            `Child is not literal: ${sourceText.slice(
+              child.expression.pos,
+              child.expression.end
+            )}`
+          )
+
           return {
-            type: 'tag',
-            children: [],
-            // set to `false` to match i18next's behavior (non-self closing, indexed instead of named)
-            isBasic: false,
-            // unused when `isBasic` is set to `false`
-            name: '',
-            // self-closing is only for named tags
-            selfClosing: false,
+            type: 'text',
+            content: '',
           }
         } else {
           throw new Error('Unknown ast element when parsing jsx: ' + child.kind)

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -233,10 +233,10 @@ describe('JsxLexer', () => {
     it('erases tags from content', (done) => {
       const Lexer = new JsxLexer()
       const content =
-        '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>'
+        '<Trans>a<b test={"</b>"}>c<c>z</c></b><br stuff={y}/></Trans>'
       assert.equal(
         Lexer.extract(content)[0].defaultValue,
-        'a<1>c<1>z</1></1><2></2><3></3>'
+        'a<1>c<1>z</1></1><2></2>'
       )
       done()
     })
@@ -411,10 +411,10 @@ describe('JsxLexer', () => {
       it('erases tags from content', (done) => {
         const Lexer = new JsxLexer()
         const content =
-          '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>'
+          '<Trans>a<b test={"</b>"}>c<c>z</c></b><br stuff={y}/></Trans>'
         assert.equal(
           Lexer.extract(content)[0].defaultValue,
-          'a<1>c<1>z</1></1><2></2><3></3>'
+          'a<1>c<1>z</1></1><2></2>'
         )
         done()
       })
@@ -479,13 +479,19 @@ describe('JsxLexer', () => {
         done()
       })
 
-      it('treats non-identify functions as normal expressions', (done) => {
+      it('emits warning on non-literal child', (done) => {
         const Lexer = new JsxLexer({
           transIdentityFunctionsToIgnore: ['funcCall'],
         })
         const content = '<Trans>Hi, {anotherFuncCall({ name: "John" })}</Trans>'
+        Lexer.on('warning', (message) => {
+          assert.equal(
+            message,
+            'Child is not literal: anotherFuncCall({ name: "John" })'
+          )
+          done()
+        })
         assert.equal(Lexer.extract(content)[0].defaultValue, 'Hi, <1></1>')
-        done()
       })
     })
   })

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -236,7 +236,7 @@ describe('JsxLexer', () => {
         '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>'
       assert.equal(
         Lexer.extract(content)[0].defaultValue,
-        'a<1>c<1>z</1></1>{d}<3></3>'
+        'a<1>c<1>z</1></1><2></2><3></3>'
       )
       done()
     })
@@ -414,7 +414,7 @@ describe('JsxLexer', () => {
           '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>'
         assert.equal(
           Lexer.extract(content)[0].defaultValue,
-          'a<1>c<1>z</1></1>{d}<3></3>'
+          'a<1>c<1>z</1></1><2></2><3></3>'
         )
         done()
       })
@@ -479,15 +479,12 @@ describe('JsxLexer', () => {
         done()
       })
 
-      it('leaves non-identify functions alone', (done) => {
+      it('treats non-identify functions as normal expressions', (done) => {
         const Lexer = new JsxLexer({
           transIdentityFunctionsToIgnore: ['funcCall'],
         })
         const content = '<Trans>Hi, {anotherFuncCall({ name: "John" })}</Trans>'
-        assert.equal(
-          Lexer.extract(content)[0].defaultValue,
-          'Hi, {anotherFuncCall({ name: "John" })}'
-        )
+        assert.equal(Lexer.extract(content)[0].defaultValue, 'Hi, <1></1>')
         done()
       })
     })

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -233,10 +233,10 @@ describe('JsxLexer', () => {
     it('erases tags from content', (done) => {
       const Lexer = new JsxLexer()
       const content =
-        '<Trans>a<b test={"</b>"}>c<c>z</c></b><br stuff={y}/></Trans>'
+        '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>'
       assert.equal(
         Lexer.extract(content)[0].defaultValue,
-        'a<1>c<1>z</1></1><2></2>'
+        'a<1>c<1>z</1></1>{d}<3></3>'
       )
       done()
     })
@@ -411,10 +411,10 @@ describe('JsxLexer', () => {
       it('erases tags from content', (done) => {
         const Lexer = new JsxLexer()
         const content =
-          '<Trans>a<b test={"</b>"}>c<c>z</c></b><br stuff={y}/></Trans>'
+          '<Trans>a<b test={"</b>"}>c<c>z</c></b>{d}<br stuff={y}/></Trans>'
         assert.equal(
           Lexer.extract(content)[0].defaultValue,
-          'a<1>c<1>z</1></1><2></2>'
+          'a<1>c<1>z</1></1>{d}<3></3>'
         )
         done()
       })

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -489,9 +489,12 @@ describe('JsxLexer', () => {
             message,
             'Child is not literal: anotherFuncCall({ name: "John" })'
           )
-          done()
         })
-        assert.equal(Lexer.extract(content)[0].defaultValue, 'Hi, <1></1>')
+        assert.equal(
+          Lexer.extract(content)[0].defaultValue,
+          'Hi, {anotherFuncCall({ name: "John" })}'
+        )
+        done()
       })
     })
   })


### PR DESCRIPTION
### Why am I submitting this PR
We noticed in our project that JSX expressions were being extracted incorrectly. We noticed this by setting `debug: true` when initializing i18next, then seeing that expressions were extracted as empty non-self-closing tags.

### Does it fix an existing ticket?
No.

### Checklist
- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
