### PR TITLE
chore: add missing `componentFunctions` properties to `JsxLexerConfig` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,7 @@ export interface JsxLexerConfig {
   lexer: "JsxLexer";
   functions?: string[];
   namespaceFunctions?: string[];
+  componentFunctions?: string[];
   attr?: string;
   transSupportBasicHtmlNodes?: boolean;
   transKeepBasicHtmlNodesFor?: string[];
@@ -55,6 +56,7 @@ export interface JsxWithTypesLexerConfig {
   lexer: "JsxLexer";
   functions?: string[];
   namespaceFunctions?: string[];
+  componentFunctions?: string[];
   attr?: string;
   transSupportBasicHtmlNodes?: boolean;
   transKeepBasicHtmlNodesFor?: string[];


### PR DESCRIPTION
### Why am I submitting this PR

The `componentFunctions` property is missing from the parser type, though is [documented here](https://github.com/i18next/i18next-parser#jsx).

### Does it fix an existing ticket?

Yes, #842.

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added (N/A - documentation already correct)
