### PR TITLE
fix: suppress warning about non-literal child when key/defaults are specified

### DIFF
--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -537,32 +537,17 @@ describe('JsxLexer', () => {
         done()
       })
 
-      describe('when i18nKey is given', () => {
-        it('does not emit a warning when given a non-literal child', (done) => {
-          const Lexer = new JsxLexer({
-            transIdentityFunctionsToIgnore: ['funcCall'],
-          })
-          const content =
-            '<Trans i18nKey="testkey">Hi, {anotherFuncCall({ name: "John" })}</Trans>'
-          const spy = sinon.spy()
-          Lexer.on('warning', spy)
-          assert.equal(Lexer.extract(content)[0].defaultValue, 'test')
-          assert.isFalse(spy.called)
-          done()
+      it('does not emit a warning about non-literal child when defaults and i18nKey are specified', (done) => {
+        const Lexer = new JsxLexer({
+          transIdentityFunctionsToIgnore: ['funcCall'],
         })
-
-        it('does not emit a warning when defaults are specified and given a non-literal child', (done) => {
-          const Lexer = new JsxLexer({
-            transIdentityFunctionsToIgnore: ['funcCall'],
-          })
-          const content =
-            '<Trans i18nKey="testkey" defaults="test">{anotherFuncCall({ name: "John" })}</Trans>'
-          const spy = sinon.spy()
-          Lexer.on('warning', spy)
-          assert.equal(Lexer.extract(content)[0].defaultValue, 'test')
-          assert.isFalse(spy.called)
-          done()
-        })
+        const content =
+          '<Trans i18nKey="testkey" defaults="test">{anotherFuncCall({ name: "John" })}</Trans>'
+        const spy = sinon.spy()
+        Lexer.on('warning', spy)
+        assert.equal(Lexer.extract(content)[0].defaultValue, 'test')
+        assert.isFalse(spy.called)
+        done()
       })
     })
   })

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -1,4 +1,5 @@
 import { assert } from 'chai'
+import sinon from 'sinon'
 import JsxLexer from '../../src/lexers/jsx-lexer.js'
 
 describe('JsxLexer', () => {
@@ -534,6 +535,34 @@ describe('JsxLexer', () => {
           'Hi, {anotherFuncCall({ name: "John" })}'
         )
         done()
+      })
+
+      describe('when i18nKey is given', () => {
+        it('does not emit a warning when given a non-literal child', (done) => {
+          const Lexer = new JsxLexer({
+            transIdentityFunctionsToIgnore: ['funcCall'],
+          })
+          const content =
+            '<Trans i18nKey="testkey">Hi, {anotherFuncCall({ name: "John" })}</Trans>'
+          const spy = sinon.spy()
+          Lexer.on('warning', spy)
+          assert.equal(Lexer.extract(content)[0].defaultValue, 'test')
+          assert.isFalse(spy.called)
+          done()
+        })
+
+        it('does not emit a warning when defaults are specified and given a non-literal child', (done) => {
+          const Lexer = new JsxLexer({
+            transIdentityFunctionsToIgnore: ['funcCall'],
+          })
+          const content =
+            '<Trans i18nKey="testkey" defaults="test">{anotherFuncCall({ name: "John" })}</Trans>'
+          const spy = sinon.spy()
+          Lexer.on('warning', spy)
+          assert.equal(Lexer.extract(content)[0].defaultValue, 'test')
+          assert.isFalse(spy.called)
+          done()
+        })
       })
     })
   })


### PR DESCRIPTION
### Why am I submitting this PR

Suppress warnings about non-literal children when both the key and defaults are specified

### Does it fix an existing ticket?

Yes #899

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
