### PR TITLE
fix: add check for keepRemoved in failOnUpdate

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -112,7 +112,9 @@ function dotPathToHash(entry, target = {}, options = {}) {
  * `new` and `oldCount` is the number of keys that were either added to `old` or
  * `new` (if `options.keepRemoved` is true and `target` didn't have the corresponding
  * key) and `reset` is the keys that were reset due to not matching default values,
- *  and `resetCount` which is the number of keys reset.
+ *  and `resetCount` which is the number of keys reset, and keyWasAdded which is
+ *  true if any key added.
+ *
  */
 function mergeHashes(source, target, options = {}, resetValues = {}) {
   let old = {}
@@ -121,6 +123,7 @@ function mergeHashes(source, target, options = {}, resetValues = {}) {
   let pullCount = 0
   let oldCount = 0
   let resetCount = 0
+  let keyWasAdded = false
 
   const keepRemoved =
     (typeof options.keepRemoved === 'boolean' && options.keepRemoved) || false
@@ -198,6 +201,7 @@ function mergeHashes(source, target, options = {}, resetValues = {}) {
         if (keepKey) {
           target[key] = source[key]
         } else {
+          keyWasAdded = true
           old[key] = source[key]
         }
         oldCount += 1
@@ -213,6 +217,7 @@ function mergeHashes(source, target, options = {}, resetValues = {}) {
     oldCount,
     reset,
     resetCount,
+    keyWasAdded,
   }
 }
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -58,7 +58,6 @@ export default class i18nTransform extends Transform {
     this.entries = []
 
     this.parserHadWarnings = false
-    this.parserHadUpdate = false
     this.parser = new Parser(this.options)
     this.parser.on('error', (error) => this.error(error))
     this.parser.on('warning', (warning) => this.warn(warning))
@@ -230,6 +229,7 @@ export default class i18nTransform extends Transform {
           oldCount,
           reset: resetFlags,
           resetCount,
+          keyWasAdded,
         } = mergeHashes(
           existingCatalog,
           catalog[namespace],
@@ -276,13 +276,8 @@ export default class i18nTransform extends Transform {
           console.log('')
         }
 
-        if (this.options.failOnUpdate) {
-          const addCount = uniqueCount[namespace] - mergeCount
-          const unreferencedCount = this.options.keepRemoved ? oldCount : 0;
-          if (addCount + restoreCount + oldCount - unreferencedCount !== 0) {
-            this.parserHadUpdate = true
-            continue
-          }
+        if (this.options.failOnUpdate && keyWasAdded) {
+          continue
         }
 
         if (this.options.failOnWarnings && this.parserHadWarnings) {
@@ -320,7 +315,7 @@ export default class i18nTransform extends Transform {
       process.exit(1)
     }
 
-    if (this.options.failOnUpdate && this.parserHadUpdate) {
+    if (this.options.failOnUpdate && keyWasAdded) {
       this.emit(
         'error',
         'Some translations was updated and failOnUpdate option is enabled. Exiting...'

--- a/src/transform.js
+++ b/src/transform.js
@@ -278,7 +278,8 @@ export default class i18nTransform extends Transform {
 
         if (this.options.failOnUpdate) {
           const addCount = uniqueCount[namespace] - mergeCount
-          if (addCount + restoreCount + oldCount !== 0) {
+          const unreferencedCount = this.options.keepRemoved ? oldCount : 0;
+          if (addCount + restoreCount + oldCount - unreferencedCount !== 0) {
             this.parserHadUpdate = true
             continue
           }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1990,6 +1990,122 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    describe.skip('failOnUpdate', () => {
+      it('fails if a translation is updated', (done) => {
+        const i18nextParser = new i18nTransform({
+          failOnUpdate: true,
+          output: 'test/locales/$LOCALE/$NAMESPACE.json',
+        })
+        const fakeFile = new Vinyl({
+          contents: Buffer.from('t("failOnUpdate")'),
+          path: 'file.js',
+        })
+
+        i18nextParser.on('error', (error) => {
+          assert.equal(
+            error,
+            'Some translations was updated and failOnUpdate option is enabled. Exiting...'
+          )
+          done()
+        })
+        i18nextParser.end(fakeFile)
+      })
+
+      it('fails if a translation is updated and keepRemoved is true', (done) => {
+        const i18nextParser = new i18nTransform({
+          failOnUpdate: true,
+          keepRemoved: true,
+        })
+        const fakeFile = new Vinyl({
+          contents: Buffer.from('t("failOnUpdate")'),
+          path: 'file.js',
+        })
+
+        i18nextParser.on('error', (error) => {
+          assert.equal(
+            error,
+            'Some translations was updated and failOnUpdate option is enabled. Exiting...'
+          )
+          done()
+        })
+        i18nextParser.end(fakeFile)
+      })
+
+      it('fails if a translation is updated and keepRemoved is a regex', (done) => {
+        const i18nextParser = new i18nTransform({
+          failOnUpdate: true,
+          keepRemoved: [/test_merge:s.*/],
+        })
+        const fakeFile = new Vinyl({
+          contents: Buffer.from('t("failOnUpdate")'),
+          path: 'file.js',
+        })
+
+        i18nextParser.on('error', (error) => {
+          assert.equal(
+            error,
+            'Some translations was updated and failOnUpdate option is enabled. Exiting...'
+          )
+          done()
+        })
+        i18nextParser.end(fakeFile)
+      })
+
+      it('passes when no translations are updated', (done) => {
+        const i18nextParser = new i18nTransform({ failOnUpdate: true })
+
+        const fakeFile = new Vinyl({
+          contents: Buffer.from('t("first")'),
+          path: 'file.js',
+        })
+
+        i18nextParser.on('error', (error) => {
+          assert.fail(error)
+        })
+
+        i18nextParser.end(fakeFile)
+        done()
+      })
+
+      it('passes when no translations are updated and keepRemoved is true', (done) => {
+        const i18nextParser = new i18nTransform({
+          failOnUpdate: true,
+          keepRemoved: true,
+        })
+
+        const fakeFile = new Vinyl({
+          contents: Buffer.from('t("first")'),
+          path: 'file.js',
+        })
+
+        i18nextParser.on('error', (error) => {
+          assert.fail(error)
+        })
+
+        i18nextParser.end(fakeFile)
+        done()
+      })
+
+      it('passes when no translations are updated and keepRemoved is a regex', (done) => {
+        const i18nextParser = new i18nTransform({
+          failOnUpdate: true,
+          keepRemoved: [/test_merge:s.*/],
+        })
+
+        const fakeFile = new Vinyl({
+          contents: Buffer.from('t("first")'),
+          path: 'file.js',
+        })
+
+        i18nextParser.on('error', (error) => {
+          assert.fail(error)
+        })
+
+        i18nextParser.end(fakeFile)
+        done()
+      })
+    })
+
     describe('lexers', () => {
       it('supports custom lexers options', (done) => {
         let result


### PR DESCRIPTION
### Why am I submitting this PR

This issue adds a check for keepRemoved in the calculation of the files changed for failOnUpdate.

### Does it fix an existing ticket?

Yes #666

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
