### PR TITLE
Handle attribute spreads

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -225,7 +225,9 @@ export default class JsxLexer extends JavascriptLexer {
           const name = element.tagName.escapedText
           const isBasic = !element.attributes.properties.length
           const hasDynamicChildren = element.attributes.properties.find(
-            (prop) => prop.name.escapedText === 'i18nIsDynamicList'
+            (prop) =>
+              prop.kind === ts.SyntaxKind.JsxAttribute &&
+              prop.name.escapedText === 'i18nIsDynamicList'
           )
           return {
             type: 'tag',

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -275,6 +275,17 @@ describe('JsxLexer', () => {
       done()
     })
 
+    it('handles spread attributes', (done) => {
+      const Lexer = new JsxLexer()
+      const content =
+        '<Trans>My dog is named: <span {...styles}>Spot</span></Trans>'
+      assert.equal(
+        Lexer.extract(content)[0].defaultValue,
+        'My dog is named: <1>Spot</1>'
+      )
+      done()
+    })
+
     it('erases comment expressions', (done) => {
       const Lexer = new JsxLexer()
       const content = '<Trans>{/* some comment */}Some Content</Trans>'


### PR DESCRIPTION
### Why am I submitting this PR

Fix handling of spread attributes when evaluating JSX attributes within `<Trans>`.

### Does it fix an existing ticket?

Fixes #908

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
