### PR TITLE
Support custom namespaced functions and components

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -91,7 +91,9 @@ export default class JsxLexer extends JavascriptLexer {
 
     const getKey = (node) => getPropValue(node, this.attr)
 
-    if (this.componentFunctions.includes(tagNode.tagName.text)) {
+    if (
+      this.componentFunctions.includes(this.expressionToName(tagNode.tagName))
+    ) {
       const entry = {}
       entry.key = getKey(tagNode)
 

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -164,11 +164,13 @@ describe('JavascriptLexer', () => {
   })
 
   it('supports a `functions` option', (done) => {
-    const Lexer = new JavascriptLexer({ functions: ['tt', '_e'] })
-    const content = 'tt("first") + _e("second")'
+    const Lexer = new JavascriptLexer({ functions: ['tt', '_e', 'f.g'] })
+    const content = 'tt("first") + _e("second") + x.tt("third") + f.g("fourth")'
     assert.deepEqual(Lexer.extract(content), [
       { key: 'first' },
       { key: 'second' },
+      { key: 'third' },
+      { key: 'fourth' },
     ])
     done()
   })

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -180,17 +180,27 @@ describe('JsxLexer', () => {
 
     it('extracts keys from user-defined components', (done) => {
       const Lexer = new JsxLexer({
-        componentFunctions: ['Translate', 'FooBar'],
+        componentFunctions: [
+          'Translate',
+          'FooBar',
+          'Namespace.A',
+          'Double.Namespace.B',
+        ],
       })
       const content = `<div>
       <Translate i18nKey="something">Something to translate.</Translate>
       <NotSupported i18nKey="jkl">asdf</NotSupported>
+      <NotSupported.Translate i18nKey="jkl">asdf</NotSupported.Translate>
       <FooBar i18nKey="asdf">Lorum Ipsum</FooBar>
+      <Namespace.A i18nKey="namespaced">Namespaced</Namespace.A>
+      <Double.Namespace.B i18nKey="namespaced2">Namespaced2</Double.Namespace.B>
       </div>
       `
       assert.deepEqual(Lexer.extract(content), [
         { key: 'something', defaultValue: 'Something to translate.' },
         { key: 'asdf', defaultValue: 'Lorum Ipsum' },
+        { key: 'namespaced', defaultValue: 'Namespaced' },
+        { key: 'namespaced2', defaultValue: 'Namespaced2' },
       ])
       done()
     })


### PR DESCRIPTION
### Why am I submitting this PR

To support matching namespaced functions and components like `Strings.get` and `<Strings.Text>`.

### Does it fix an existing ticket?

Yes https://github.com/i18next/i18next-parser/issues/912

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added – I'll be happy to add docs for this, but the existing docs should already be enough