### PR TITLE
Compat: Make tests work on Windows with non-English locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "coverage": "c8 --all --include='src/**/*[.js|.jsx|.ts|.tsx]' --reporter=lcov --reporter=text yarn test",
     "test": "mocha -r @babel/register -r @babel/polyfill --recursive test/*.test.js test/**/*.test.js",
-    "test:cli": "yarn -s build && ./bin/cli.js '**/*.html' -o 'test/manual/$LOCALE/$NAMESPACE.json' && ./bin/cli.js -c test/cli/i18next-parser.config.js && ./bin/cli.js -c test/cli/i18next-parser.config.mjs && ./bin/cli.js -c test/cli/i18next-parser.config.ts && ./bin/cli.js -c test/cli/i18next-parser.config.yaml",
+    "test:cli": "yarn -s build && node ./bin/cli.js '**/*.html' -o test/manual/$LOCALE/$NAMESPACE.json && node ./bin/cli.js -c test/cli/i18next-parser.config.js && node ./bin/cli.js -c test/cli/i18next-parser.config.mjs && node ./bin/cli.js -c test/cli/i18next-parser.config.ts && node ./bin/cli.js -c test/cli/i18next-parser.config.yaml",
     "test:watch": "mocha -r @babel/register -r @babel/polyfill --watch --parallel --recursive",
     "watch": "babel src -d dist -w",
     "prettify": "prettier --write \"{src,test}/**/*.js\"",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -272,7 +272,7 @@ function makeDefaultSort(pluralSeparator) {
       return getPluralSuffixPosition(key1) - getPluralSuffixPosition(key2)
     }
 
-    return singularKey1.localeCompare(singularKey2)
+    return singularKey1.localeCompare(singularKey2, 'en')
   }
 }
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1348,6 +1348,7 @@ describe('parser', () => {
 
       const i18nextParser = new i18nTransform({
         output: 'locales/$LOCALE/$NAMESPACE.json',
+        lineEnding: 'lf',
       })
       const fakeFile = new Vinyl({
         contents: Buffer.from("t('nbsp', 'Oné\\u00A0Twó\\u3000Three Four')"),
@@ -2339,7 +2340,7 @@ describe('parser', () => {
       it('supports sort as a function', (done) => {
         let result
         const i18nextParser = new i18nTransform({
-          sort: (a, b) => a.slice(0, -1).localeCompare(b.slice(0, -1)),
+          sort: (a, b) => a.slice(0, -1).localeCompare(b.slice(0, -1), 'ar'),
           locales: ['ar'],
         })
         const fakeFile = new Vinyl({


### PR DESCRIPTION
### Why am I submitting this PR

I originally started investigating the Broccoli problems mentioned in #684 on a Windows computer, running with some Danish locale settings. This caused a number of problems, from my editor opening bin/cli.js instead of running the code to sorting and line-ending issues with some tests. 

Assuming the assertions to be the one source of truth, I've added a locale parameter in localeCompare for the default comparison function. lineEndings are set to `lf` for a test that checks the entire contents of a generated JSON file.

### Does it fix an existing ticket?

No

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [X] documentation is changed or added
