### PR TITLE
Sort & failOnUpdate

### DIFF
--- a/test/locales/en/test_sort.json
+++ b/test/locales/en/test_sort.json
@@ -1,0 +1,4 @@
+{
+  "second": "second",
+  "first": "first"
+}

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -619,6 +619,36 @@ describe('parser', () => {
     i18nextParser.end(fakeFile)
   })
 
+  it('fails on sort with failOnUpdate option', (done) => {
+    const i18nextParser = new i18nTransform({
+      output: 'test/locales/$LOCALE/$NAMESPACE.json',
+      failOnUpdate: true,
+      locales: ['en'],
+      sort: true,
+    })
+    const fakeFile = new Vinyl({
+      contents: Buffer.from("t('test_sort:first'), t('test_sort:second')"),
+      path: 'file.js',
+    })
+
+    let actualError
+    i18nextParser.once('error', (error) => {
+      actualError = error
+    })
+
+    const realExit = process.exit
+    process.exit = (exitCode) => {
+      process.exit = realExit
+      assert.equal(exitCode, 1)
+      assert.equal(
+        actualError,
+        'Some keys were sorted and failOnUpdate option is enabled. Exiting...'
+      )
+      done()
+    }
+    i18nextParser.end(fakeFile)
+  })
+
   it('restores translations from the old catalog', (done) => {
     const i18nextParser = new i18nTransform({
       output: 'test/locales/$LOCALE/$NAMESPACE.json',


### PR DESCRIPTION
### Why am I submitting this PR

Exit with exit code 1 when `sort` and `failOnUpdate` are set and keys are not already sorted

### Does it fix an existing ticket?

Fixes #926

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
