### PR TITLE
Fix --fail-on-update false negatives from new sort code.

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -298,21 +298,21 @@ export default class i18nTransform extends Transform {
             typeof sort === 'function'
               ? sort
               : makeDefaultSort(this.options.pluralSeparator)
-          let wrappedCompare = this.options.failOnUpdate
-            ? (...args) => {
-                const result = compare(...args)
-                if (result > 0) {
-                  this.parserHadSortUpdate = true
-                  wrappedCompare = compare
-                }
-                return result
-              }
-            : compare
           maybeSortedNewCatalog = sortKeys(newCatalog, {
             deep: true,
-            compare: wrappedCompare,
+            compare,
           })
+
           maybeSortedOldCatalog = sortKeys(oldCatalog, { deep: true, compare })
+
+          if (this.options.failOnUpdate && !this.parserHadUpdate) {
+            // No updates to the catalog, so we do the deeper check to ensure it is also sorted.
+            // This is easiest to accomplish by simply converting both objects to JSON, as we'd have
+            // to do a deep comparison anyway
+            this.parserHadSortUpdate =
+              JSON.stringify(maybeSortedNewCatalog) !==
+              JSON.stringify(existingCatalog)
+          }
         }
 
         // push files back to the stream

--- a/test/locales/en/test_sort.json
+++ b/test/locales/en/test_sort.json
@@ -1,4 +1,0 @@
-{
-  "second": "second",
-  "first": "first"
-}

--- a/test/locales/en/test_sort_sorted.json
+++ b/test/locales/en/test_sort_sorted.json
@@ -1,0 +1,8 @@
+{
+  "first": "first",
+  "second": "second",
+  "third": {
+    "a": "a",
+    "b": "b"
+  }
+}

--- a/test/locales/en/test_sort_unsorted.json
+++ b/test/locales/en/test_sort_unsorted.json
@@ -1,0 +1,8 @@
+{
+  "second": "second",
+  "first": "first",
+  "third": {
+    "b": "b",
+    "a": "a"
+  }
+}


### PR DESCRIPTION
This replaces the code that previously tried to check for sorting via a wrapped `compare` function with a much simpler approach: JSON encode the old and (sorted) new version and see if they match. This code only runs if we have not already seen an update to the keys/contents before, so the performance implications are minimal.

This also adds a test to ensure that false negatives don't occur (i.e. it checks the --fail-on-update behavior against a file that is not being updated and was already sorted).

Fixes #955.

### Why am I submitting this PR

The previous update broke --fail-on-update, making it always fail if sorting was configured.

### Does it fix an existing ticket?

Yes #955

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
