### PR TITLE
Use utf-8 as default encoding to read files

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -99,7 +99,7 @@ export default class i18nTransform extends Transform {
       done()
       return
     } else {
-      content = fs.readFileSync(file.path, encoding)
+      content = fs.readFileSync(file.path, encoding || 'utf-8')
     }
 
     this.emit('reading', file)


### PR DESCRIPTION
The encoding set on the transform is technically supposed to be used for the chunks going through the transform itself, and it's not necessarily set for a Transform, especially in object mode.  This falls back on `utf-8` as the encoding when loading a file from disk.

I suspect this should just always use `utf-8` always but I can't say for sure there isn't a use case for using the `encoding` parameter.
