### PR TITLE
Fix plurals not being detected when count is a CallExpression

### DIFF
--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -323,6 +323,8 @@ export default class JavascriptLexer extends BaseLexer {
               const nestedEntries = this.expressionExtractor(p.initializer)
               if (nestedEntries) {
                 entries.push(...nestedEntries)
+              } else {
+                entries[0][p.name.text] = p.initializer.text || ''
               }
             } else {
               entries[0][p.name.text] = p.initializer.text || ''

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1638,6 +1638,30 @@ describe('parser', () => {
       i18nextParser.end(fakeFile)
     })
 
+    it('generates plurals when count is an expression', (done) => {
+      let result
+      const i18nextParser = new i18nTransform()
+      const fakeFile = new Vinyl({
+        contents: Buffer.from("t('test {{count}}', { count: expr() })"),
+        path: 'file.js',
+      })
+
+      i18nextParser.on('data', (file) => {
+        if (file.relative.endsWith(enLibraryPath)) {
+          result = JSON.parse(file.contents)
+        }
+      })
+      i18nextParser.once('end', () => {
+        assert.deepEqual(result, {
+          'test {{count}}_one': '',
+          'test {{count}}_other': '',
+        })
+        done()
+      })
+
+      i18nextParser.end(fakeFile)
+    })
+
     it('generates plurals with custom plural separator', (done) => {
       let result
       const i18nextParser = new i18nTransform({


### PR DESCRIPTION
### Why am I submitting this PR

Addresses https://github.com/i18next/i18next-parser/issues/1015 where the JavaScript lexer would no longer correctly identify plurals where the count was a CallExpression

### Does it fix an existing ticket?

Yes #1015

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] ~documentation is changed or added~
