### PR TITLE
Fix JSX key attribute clobbering detected value

### DIFF
--- a/src/lexers/jsx-lexer.js
+++ b/src/lexers/jsx-lexer.js
@@ -15,7 +15,7 @@ export default class JsxLexer extends JavascriptLexer {
       'i',
       'p',
     ]
-    this.omitAttributes = [this.attr, 'ns', 'defaults']
+    this.omitAttributes = [this.attr, 'ns', 'key', 'defaults']
     this.transIdentityFunctionsToIgnore =
       options.transIdentityFunctionsToIgnore || []
   }

--- a/test/lexers/jsx-lexer.test.js
+++ b/test/lexers/jsx-lexer.test.js
@@ -43,6 +43,16 @@ describe('JsxLexer', () => {
       done()
     })
 
+    it('ignores the protected React key attribute when defined', (done) => {
+      const Lexer = new JsxLexer()
+      const content =
+        '<Trans key="foo" i18nKey="first" count={count}>Yo</Trans>'
+      assert.deepEqual(Lexer.extract(content), [
+        { key: 'first', defaultValue: 'Yo', count: '{count}' },
+      ])
+      done()
+    })
+
     it('extracts default value from string literal `defaults` prop', (done) => {
       const Lexer = new JsxLexer()
       const content =


### PR DESCRIPTION
### Why am I submitting this PR

React components have a protected attribute "key" which can seemingly clobber the detected/parsed i18n key due to a naming conflict.

### Does it fix an existing ticket?

Yes #1038

### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [X] documentation is changed or added
