### PR TITLE
style: run prettier on all files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+indent_style = space
+indent_size = 2
+
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: /
-  target-branch: master
-  schedule:
-    interval: daily
-- package-ecosystem: github-actions
-  directory: /
-  target-branch: master
-  schedule:
-    interval: daily
+  - package-ecosystem: npm
+    directory: /
+    target-branch: master
+    schedule:
+      interval: daily
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: master
+    schedule:
+      interval: daily

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,7 @@ npm-debug.log
 .idea/
 
 # manual test files
-test/manual/en
-test/manual/fr
+test/manual/
 
 # coverage
 .nyc_output

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,3 +1,3 @@
 export default {
-  '*.{js,css,md}': 'yarn prettify',
+  '*': 'prettier --write --ignore-unknown',
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
+test/broccoli/src/handlebars.hbs
 test/broccoli/src/javascript.js
-test/templating/javascript.js
+test/locales/en/test_invalid.json
+test/templating/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,67 +1,71 @@
-import EventEmitter from "events";
+import EventEmitter from 'events'
 
-export type SupportedLexer = "HandlebarsLexer" | "HTMLLexer" | "JavascriptLexer" | "JsxLexer";
+export type SupportedLexer =
+  | 'HandlebarsLexer'
+  | 'HTMLLexer'
+  | 'JavascriptLexer'
+  | 'JsxLexer'
 
 // BaseLexer is not importable therefore this is the best if done simple
 export class CustomLexerClass extends EventEmitter {}
-export type CustomLexer = typeof CustomLexerClass;
+export type CustomLexer = typeof CustomLexerClass
 
 export interface CustomLexerConfig extends Record<string, unknown> {
-  lexer: CustomLexer;
+  lexer: CustomLexer
 }
 
 export interface HandlebarsLexerConfig {
-  lexer: "HandlebarsLexer";
-  functions?: string[];
+  lexer: 'HandlebarsLexer'
+  functions?: string[]
 }
 
 export interface HTMLLexerConfig {
-  lexer: "HTMLLexer";
-  functions?: string[];
-  attr?: string;
-  optionAttr?: string;
+  lexer: 'HTMLLexer'
+  functions?: string[]
+  attr?: string
+  optionAttr?: string
 }
 
 export interface JavascriptLexerConfig {
-  lexer: "JavascriptLexer";
-  functions?: string[];
-  namespaceFunctions?: string[];
-  attr?: string;
-  parseGenerics?: false;
-  typeMap?: Record<string, unknown>;
+  lexer: 'JavascriptLexer'
+  functions?: string[]
+  namespaceFunctions?: string[]
+  attr?: string
+  parseGenerics?: false
+  typeMap?: Record<string, unknown>
 }
 
 export interface JavascriptWithTypesLexerConfig {
-  lexer: "JavascriptLexer";
-  functions?: string[];
-  namespaceFunctions?: string[];
-  attr?: string;
-  parseGenerics: true;
-  typeMap: Record<string, unknown>;
+  lexer: 'JavascriptLexer'
+  functions?: string[]
+  namespaceFunctions?: string[]
+  attr?: string
+  parseGenerics: true
+  typeMap: Record<string, unknown>
 }
 
 export interface JsxLexerConfig {
-  lexer: "JsxLexer";
-  functions?: string[];
-  namespaceFunctions?: string[];
-  componentFunctions?: string[];
-  attr?: string;
-  transSupportBasicHtmlNodes?: boolean;
-  transKeepBasicHtmlNodesFor?: string[];
-  parseGenerics?: false;
-  typeMap?: Record<string, unknown>;
+  lexer: 'JsxLexer'
+  functions?: string[]
+  namespaceFunctions?: string[]
+  componentFunctions?: string[]
+  attr?: string
+  transSupportBasicHtmlNodes?: boolean
+  transKeepBasicHtmlNodesFor?: string[]
+  parseGenerics?: false
+  typeMap?: Record<string, unknown>
 }
 
 export interface JsxWithTypesLexerConfig {
-  lexer: "JsxLexer";
-  functions?: string[];
-  namespaceFunctions?: string[];
-  componentFunctions?: string[];
-  attr?: string;
-  transSupportBasicHtmlNodes?: boolean;
-  transKeepBasicHtmlNodesFor?: string[];
-  parseGenerics: true;
-  typeMap: Record<string, unknown>;
+  lexer: 'JsxLexer'
+  functions?: string[]
+  namespaceFunctions?: string[]
+  componentFunctions?: string[]
+  attr?: string
+  transSupportBasicHtmlNodes?: boolean
+  transKeepBasicHtmlNodesFor?: string[]
+  parseGenerics: true
+  typeMap: Record<string, unknown>
   /**
    * Identity functions within trans that should be parsed for their
    * first arguments. Used for making typecheckers happy in a safe way: e.g., if in your code, you use:
@@ -72,7 +76,7 @@ export interface JsxWithTypesLexerConfig {
    *
    * you'd want to pass in `transIdentityFunctionsToIgnore: ['castToString']`
    */
-  transIdentityFunctionsToIgnore?: string[];
+  transIdentityFunctionsToIgnore?: string[]
 }
 
 export type LexerConfig =
@@ -82,40 +86,47 @@ export type LexerConfig =
   | JavascriptWithTypesLexerConfig
   | JsxLexerConfig
   | JsxWithTypesLexerConfig
-  | CustomLexerConfig;
+  | CustomLexerConfig
 
 export interface UserConfig {
-  contextSeparator?: string;
-  createOldCatalogs?: boolean;
-  defaultNamespace?: string;
-  defaultValue?: string | ((locale?: string, namespace?: string, key?: string, value?: string) => string);
-  indentation?: number;
-  keepRemoved?: boolean | readonly RegExp[];
-  keySeparator?: string | false;
+  contextSeparator?: string
+  createOldCatalogs?: boolean
+  defaultNamespace?: string
+  defaultValue?:
+    | string
+    | ((
+        locale?: string,
+        namespace?: string,
+        key?: string,
+        value?: string
+      ) => string)
+  indentation?: number
+  keepRemoved?: boolean | readonly RegExp[]
+  keySeparator?: string | false
   lexers?: {
-    hbs?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    handlebars?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    htm?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    html?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    mjs?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    js?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    ts?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    jsx?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    tsx?: (SupportedLexer | CustomLexer | LexerConfig)[];
-    default?: (SupportedLexer | CustomLexer | LexerConfig)[];
-  };
-  lineEnding?: "auto" | "crlf" | "\r\n" | "cr" | "\r" | "lf" | "\n";
-  locales?: string[];
-  namespaceSeparator?: string | false;
-  output?: string;
-  pluralSeparator?: string;
-  input?: string | string[];
-  sort?: boolean | ((a: string, b: string) => -1 | 0 | 1);
-  verbose?: boolean;
-  failOnWarnings?: boolean;
-  failOnUpdate?: boolean;
-  customValueTemplate?: Record<string, string> | null;
-  resetDefaultValueLocale?: string | null;
-  i18nextOptions?: Record<string, unknown> | null;
-  yamlOptions?: Record<string, unknown> | null;
+    hbs?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    handlebars?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    htm?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    html?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    mjs?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    js?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    ts?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    jsx?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    tsx?: (SupportedLexer | CustomLexer | LexerConfig)[]
+    default?: (SupportedLexer | CustomLexer | LexerConfig)[]
+  }
+  lineEnding?: 'auto' | 'crlf' | '\r\n' | 'cr' | '\r' | 'lf' | '\n'
+  locales?: string[]
+  namespaceSeparator?: string | false
+  output?: string
+  pluralSeparator?: string
+  input?: string | string[]
+  sort?: boolean | ((a: string, b: string) => -1 | 0 | 1)
+  verbose?: boolean
+  failOnWarnings?: boolean
+  failOnUpdate?: boolean
+  customValueTemplate?: Record<string, string> | null
+  resetDefaultValueLocale?: string | null
+  i18nextOptions?: Record<string, unknown> | null
+  yamlOptions?: Record<string, unknown> | null
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:cli": "yarn -s build && node ./bin/cli.js '**/*.html' -o test/manual/$LOCALE/$NAMESPACE.json && node ./bin/cli.js -c test/cli/i18next-parser.config.js && node ./bin/cli.js -c test/cli/i18next-parser.config.mjs && node ./bin/cli.js -c test/cli/i18next-parser.config.ts && node ./bin/cli.js -c test/cli/i18next-parser.config.yaml",
     "test:watch": "mocha -r @babel/register -r @babel/polyfill --watch --parallel --recursive",
     "watch": "babel src -d dist -w",
-    "prettify": "prettier --write \"{src,test}/**/*.js\"",
+    "prettify": "prettier --write --list-different .",
     "build": "babel src -d dist && cp index.d.ts dist",
     "prepare": "husky install",
     "prepublishOnly": "yarn -s prettify && yarn -s build"

--- a/test/cli/html.html
+++ b/test/cli/html.html
@@ -1,33 +1,33 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="UTF-8"/>
-  <meta name="description" data-i18n="selfClosing" content="content"/>
-  <meta name="keywords" content="some keywords"/>
-  <meta name="google-site-verification" content="google-key"/>
-  <meta name="yandex-verification" content="yandex-key"/>
-  <title>Lorem ipsum dolor sit amet, consectetur adipiscing elit</title>
-</head>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" data-i18n="selfClosing" content="content" />
+    <meta name="keywords" content="some keywords" />
+    <meta name="google-site-verification" content="google-key" />
+    <meta name="yandex-verification" content="yandex-key" />
+    <title>Lorem ipsum dolor sit amet, consectetur adipiscing elit</title>
+  </head>
 
-<body id="main">
-  <div class="foobar">
-    <p data-i18n="first">First</p>
-    <p title="second" data-i18n>second</p>
-    <p data-i18n="[title]third;fourth">Fourth</p>
-    <p
-      title=""
-      bla
-      data-i18n="fifth"
-      data-i18n-options='{"defaultValue": "bar"}'
-    ></p>
-    <p
-      title=""
-      bla
-      data-i18n="sixth"
-    >asd</p>
-    <p data-i18n="seventh" data-i18n-options='{"defaultValue": "foo"}'>Seventh</p>
-    <p data-i18n="seventh" data-i18n-options='{"defaultValue": "bar"}'>Seventh</p>
-    <p data-i18n="empty:">Empty</p>
-  </div>
-</body>
+  <body id="main">
+    <div class="foobar">
+      <p data-i18n="first">First</p>
+      <p title="second" data-i18n>second</p>
+      <p data-i18n="[title]third;fourth">Fourth</p>
+      <p
+        title=""
+        bla
+        data-i18n="fifth"
+        data-i18n-options='{"defaultValue": "bar"}'
+      ></p>
+      <p title="" bla data-i18n="sixth">asd</p>
+      <p data-i18n="seventh" data-i18n-options='{"defaultValue": "foo"}'>
+        Seventh
+      </p>
+      <p data-i18n="seventh" data-i18n-options='{"defaultValue": "bar"}'>
+        Seventh
+      </p>
+      <p data-i18n="empty:">Empty</p>
+    </div>
+  </body>
 </html>

--- a/test/locales/en/test_fail_on_update.json
+++ b/test/locales/en/test_fail_on_update.json
@@ -2,4 +2,3 @@
   "key_existing_1": "exists",
   "key_existing_2": "exists"
 }
-

--- a/test/locales/en/test_old.json
+++ b/test/locales/en/test_old.json
@@ -1,6 +1,6 @@
 {
-    "parent": {
-        "first": "first"
-    },
-    "second": "second"
+  "parent": {
+    "first": "first"
+  },
+  "second": "second"
 }

--- a/test/locales/en/test_old_old.json
+++ b/test/locales/en/test_old_old.json
@@ -1,6 +1,6 @@
 {
-    "parent": {
-        "some": "some"
-    },
-    "other": "other"
+  "parent": {
+    "some": "some"
+  },
+  "other": "other"
 }


### PR DESCRIPTION
### Why am I submitting this PR

Quality of life improvement that extends the Prettier config so it runs on all files in the repo. Also adds a `.editorconfig` file that configures file formats for both Prettier ([docs](https://prettier.io/docs/en/configuration.html#editorconfig)) and modern IDEs.

### Does it fix an existing ticket?

No.

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
