### PR TITLE
chore: update dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ updates:
     target-branch: master
     schedule:
       interval: daily
+    versioning-strategy: increase
   - package-ecosystem: github-actions
     directory: /
     target-branch: master
     schedule:
       interval: daily
+    versioning-strategy: increase


### PR DESCRIPTION
### Why am I submitting this PR

Explicitly set Dependabot's `versioning-strategy` to  `increase` ([docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy)) to avoid the default behaviour of widening the allowed version or updating the lockfile only.

#### The issue this is trying to solve

The default Dependabot behaviour is to either widen the version constraint (example: `^8.0.0` becomes `^8.0.0 || ^9.0.0`) or update the lockfile only. In both cases the repo's lockfile gets updated but doesn't force a dependency update downstream. This means that while this repo is testing against the latest version of a given dependency, the projects using it might be using a version of the same dependency that's much older. This can become an issue in situations where this repo uses a feature that's only available in the newer version of the dependency (or a feature that's had a significant update to its behaviour in the newer version. Tests would pass just fine but downstream projects would crash, and there issues are often hard to debug.


#### How it solved the issue

Dependabot's versioning strategy ensures that the version in the package.json is also updated, which means that when a new release is made that includes an updated, the downstream projects force an update of that dependency as well. This keeps the repo's versions and the downstream version's in sync, and catch dependency mismatch issues early.


### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
