### PR TITLE
Fix error when using spread syntax in useTranslation options

### DIFF
--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -199,7 +199,7 @@ export default class JavascriptLexer extends BaseLexer {
         optionsArgument.kind === ts.SyntaxKind.ObjectLiteralExpression
       ) {
         const keyPrefixNode = optionsArgument.properties.find(
-          (p) => p.name.escapedText === 'keyPrefix'
+          (p) => p.name?.escapedText === 'keyPrefix'
         )
         if (keyPrefixNode != null) {
           this.keyPrefix = keyPrefixNode.initializer.text

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -274,6 +274,15 @@ describe('JavascriptLexer', () => {
       ])
     })
 
+    it('extracts namespace with spread syntax in useTranslation options', () => {
+      const Lexer = new JavascriptLexer()
+      const content =
+        'const options = {}; const {t} = useTranslation("foo", {...options}); t("bar");'
+      assert.deepEqual(Lexer.extract(content), [
+        { namespace: 'foo', key: 'bar' },
+      ])
+    })
+
     it('extracts namespace with a custom hook', () => {
       const Lexer = new JavascriptLexer({
         namespaceFunctions: ['useCustomTranslationHook'],


### PR DESCRIPTION
### Why am I submitting this PR

```
TypeError: Cannot read properties of undefined (reading 'escapedText')
```

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added
