### PR TITLE
Add namespace information to duplicate warnings

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -186,10 +186,16 @@ export default class i18nTransform extends Transform {
           if (conflict === 'key') {
             this.warn(
               `Found translation key already mapped to a map or parent of ` +
-                `new key already mapped to a string: ${entry.key}`
+                `new key already mapped to a string: ${
+                  entry.namespace + this.options.namespaceSeparator + entry.key
+                }`
             )
           } else if (conflict === 'value') {
-            this.warn(`Found same keys with different values: ${entry.key}`)
+            this.warn(
+              `Found same keys with different values: ${
+                entry.namespace + this.options.namespaceSeparator + entry.key
+              }`
+            )
           }
         } else {
           uniqueCount[entry.namespace] += 1


### PR DESCRIPTION
### Why am I submitting this PR

The warning message for duplicate keys is of limited usefulness, if it concerns a key that exists in multiple namespaces.
For example: the `title` key exists in 10 namespaces. When I get a warning that it's duplicate, I likely have accidentally used the wrong namespace somewhere, but I have no way of identifying where.

This PR Fixes this by adding the namespace to the log output.

### Does it fix an existing ticket?

No #000

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests)) (no tests relevant)
- [ ] documentation is changed or added
