### PR TITLE
Support nested property namespace functions in namespaceFunctions

### DIFF
--- a/src/lexers/javascript-lexer.js
+++ b/src/lexers/javascript-lexer.js
@@ -161,10 +161,12 @@ export default class JavascriptLexer extends BaseLexer {
   expressionExtractor(node) {
     const entries = [{}]
 
-    if (
-      this.namespaceFunctions.includes(node.expression.escapedText) &&
-      node.arguments.length
-    ) {
+    const isNamespaceFunction =
+      this.namespaceFunctions.includes(node.expression.escapedText) ||
+      // Support matching the namespace as well, i.e. match `i18n.useTranslation('ns')`
+      this.namespaceFunctions.includes(this.expressionToName(node.expression))
+
+    if (isNamespaceFunction && node.arguments.length) {
       const namespaceArgument = node.arguments[0]
       const optionsArgument = node.arguments[1]
       // The namespace argument can be either an array of namespaces or a single namespace,

--- a/test/lexers/javascript-lexer.test.js
+++ b/test/lexers/javascript-lexer.test.js
@@ -283,6 +283,16 @@ describe('JavascriptLexer', () => {
         { namespace: 'foo', key: 'bar' },
       ])
     })
+
+    it('extracts namespace with a custom hook defined as nested properties', () => {
+      const Lexer = new JavascriptLexer({
+        namespaceFunctions: ['i18n.useTranslate'],
+      })
+      const content = 'const {t} = i18n.useTranslate("foo"); t("bar");'
+      assert.deepEqual(Lexer.extract(content), [
+        { namespace: 'foo', key: 'bar' },
+      ])
+    })
   })
 
   describe('withTranslation', () => {


### PR DESCRIPTION
### Why am I submitting this PR

This PR adds support for recognizing namespace functions defined as nested properties (e.g., `i18n.useTranslate`) in the `namespaceFunctions` lexer option. This functionality brings consistency with functions and componentFunctions, which already support nested property functions.

### Does it fix an existing ticket?

Yes - [#1103](https://github.com/i18next/i18next-parser/issues/1103)

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] do no modify the version in package.json or CHANGELOG.md
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [ ] documentation is changed or added - I believe the existing documentation is sufficient, but I'm happy to add more if needed.
