### PR TITLE
feat: html lexer supports DefaultValue obtained from innerText

### DIFF
--- a/src/lexers/html-lexer.js
+++ b/src/lexers/html-lexer.js
@@ -7,6 +7,7 @@ export default class HTMLLexer extends BaseLexer {
 
     this.attr = options.attr || 'data-i18n'
     this.optionAttr = options.optionAttr || 'data-i18n-options'
+    this.innerTextDefaultValue = options.innerTextDefaultValue ?? false
   }
 
   extract(content) {
@@ -24,6 +25,17 @@ export default class HTMLLexer extends BaseLexer {
           options = JSON.parse(options)
         } finally {
         }
+      }
+
+      // whether to fill the default value
+      if (
+        (!options || options.defaultValue == undefined) &&
+        that.innerTextDefaultValue &&
+        $node.text()
+      ) {
+        if (!options) options = {}
+        const value = $node.text()
+        options.defaultValue = value
       }
 
       for (let key of keys) {


### PR DESCRIPTION
### Why am I submitting this PR

html lexer supports DefaultValue obtained from innerText

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] do no modify the version in package.json or CHANGELOG.md
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
