### PR TITLE
Add support for Node.js 24 and drop unused fields

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "i18next": "./bin/cli.js"
   },
   "engines": {
-    "node": "^18 || ^20 || ^22 || ^24"
+    "node": ">=18"
   },
   "scripts": {
     "coverage": "c8 --all --include='src/**/*[.js|.jsx|.ts|.tsx]' --reporter=lcov --reporter=text yarn test",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "i18next": "./bin/cli.js"
   },
   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || ^22.0.0",
-    "npm": ">=6",
-    "yarn": ">=1"
+    "node": "^18 || ^20 || ^22 || ^24"
   },
   "scripts": {
     "coverage": "c8 --all --include='src/**/*[.js|.jsx|.ts|.tsx]' --reporter=lcov --reporter=text yarn test",


### PR DESCRIPTION
### Why am I submitting this PR

Node.js 24 is out, so we can consider adding Node.js 24 to the engines field.

The `npm` and `yarn` fields in `engines` can be removed since those versions are too old. We can drop them gracefully.

I also updated the GitHub Actions workflow file to test with Node.js 24.

### Does it fix an existing ticket?

No

### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] do no modify the version in package.json or CHANGELOG.md
- [x] tests are included and pass: `yarn test` (see [details here](https://github.com/i18next/i18next-parser/blob/master/docs/development.md#tests))
- [x] documentation is changed or added
